### PR TITLE
Small change in test imports

### DIFF
--- a/Donut/modules/example/tests/test_routes.py
+++ b/Donut/modules/example/tests/test_routes.py
@@ -1,10 +1,10 @@
-from flask import url_for
+import flask
 
 from Donut.tests.fixtures import *
 from Donut import app
 
 def testHome(client):
-  rv = client.get(url_for('example.home'))
+  rv = client.get(flask.url_for('example.home'))
 
   assert rv.status_code == 200
   assert "Example page" in rv.data

--- a/Donut/modules/example/tests/test_routes.py
+++ b/Donut/modules/example/tests/test_routes.py
@@ -1,6 +1,6 @@
 import flask
 
-from Donut.tests.fixtures import *
+from Donut.tests.fixtures import client
 from Donut import app
 
 def testHome(client):

--- a/Donut/tests/test_routes.py
+++ b/Donut/tests/test_routes.py
@@ -1,6 +1,6 @@
 import flask
 
-from Donut.tests.fixtures import *
+from Donut.tests.fixtures import client
 from Donut import app
 
 def testHome(client):

--- a/Donut/tests/test_routes.py
+++ b/Donut/tests/test_routes.py
@@ -1,10 +1,10 @@
-from flask import url_for
+import flask
 
-from fixtures import *
+from Donut.tests.fixtures import *
 from Donut import app
 
 def testHome(client):
-  rv = client.get(url_for('home'))
+  rv = client.get(flask.url_for('home'))
 
   assert rv.status_code == 200
   assert "Hello world!" in rv.data


### PR DESCRIPTION
- We're trying to use `import flask` instead of `from flask import ...`
  throughout the repo, so I'm switching to that in the tests too.
- Use `from Donut.tests.fixtures import *` in module tests to be more
  consistent with blueprint tests.
