### PR TITLE
Fix make fresh-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ fresh-install: venv pip-install
 
 venv:
 	mkdir -p ~/virtualenvs
-	virtualenv -p /usr/local/bin/python3.6 ~/virtualenvs/donut-py3 && \
-	. ~/virtualenvs/donut-py3/bin/activate
+	virtualenv -p /usr/local/bin/python3.6 ~/virtualenvs/donut-py3
 	echo "# Virtualenv\nsource ~/virtualenvs/donut-py3/bin/activate" >> ~/.profile
 
 pip-install:
+	. ~/virtualenvs/donut-py3/bin/activate; \
 	pip install -r requirements.txt
 
 lint:


### PR DESCRIPTION
### Summary
- Properly activate virtualenv before installing with `pip install -r requirements.txt`

### Test Plan
- `rm -rf ~/virtualenvs/donut-py3; make fresh-install`
- @RobertEng test with Ziyan
