### PR TITLE
Groups positions API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ pip-install:
 lint:
 	yapf -i -r .
 
-test:
-	make init-test-db && \
+test: init-test-db
 	python -m pytest .
 
 init-test-db:

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,8 @@ lint:
 	yapf -i -r .
 
 test:
+	make init-test-db && \
 	python -m pytest .
+
+init-test-db:
+	mysql -u donut_test --password=public < sql/reset.sql

--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -4,7 +4,7 @@ import sqlalchemy
 
 def get_group_list_data(fields=None, attrs={}):
     """
-    Queries the database and returns list of group data constrained by the 
+    Queries the database and returns list of group data constrained by the
     specified attributes.
 
     Arguments:
@@ -13,7 +13,7 @@ def get_group_list_data(fields=None, attrs={}):
         attrs:  The attributes of the group to filter for.
     Returns:
         result: The fields and corresponding values of groups with desired
-                attributes. In the form of a list of dicts with key:value of 
+                attributes. In the form of a list of dicts with key:value of
                 columnname:columnvalue.
     """
     all_returnable_fields = [
@@ -40,3 +40,24 @@ def get_group_list_data(fields=None, attrs={}):
     # Return the rows in the form of a list of dicts
     result = [{f: t for f, t in zip(fields, res)} for res in result]
     return result
+
+
+group_position_fields = ["pos_id", "pos_name"]
+
+
+def get_group_positions(group_id):
+    """
+    Returns a list of all positions for a group with the given id.
+
+    Arguments:
+        group_id: The integer id of the group
+    """
+
+    query = sqlalchemy.sql.select(group_position_fields).select_from(
+        sqlalchemy.text("positions"))
+    query = query.where(sqlalchemy.text("group_id = :group_id"))
+    positions = flask.g.db.execute(query, group_id=group_id).fetchall()
+    return [{
+        field: value
+        for field, value in zip(group_position_fields, position)
+    } for position in positions]

--- a/donut/modules/groups/routes.py
+++ b/donut/modules/groups/routes.py
@@ -22,7 +22,7 @@ def get_groups_list():
 @blueprint.route("/1/groups/<int:group_id>/positions/")
 def get_group_positions(group_id):
     """GET /1/groups/<int:group_id>/positions/"""
-    return json.dumps(helpers.get_group_positions(group_id))
+    return jsonify(helpers.get_group_positions(group_id))
 
 
 @blueprint.route("/1/groups/<int:group_id>/")

--- a/donut/modules/groups/routes.py
+++ b/donut/modules/groups/routes.py
@@ -16,3 +16,9 @@ def get_groups_list():
     if "fields" in flask.request.args:
         fields = [f.strip() for f in flask.request.args["fields"].split(',')]
     return json.dumps(helpers.get_group_list_data(fields=fields, attrs=attrs))
+
+
+@blueprint.route("/1/groups/<int:group_id>/positions/")
+def get_group_positions(group_id):
+    """GET /1/groups/<int:group_id>/positions/"""
+    return json.dumps(helpers.get_group_positions(group_id))

--- a/donut/testing/fixtures.py
+++ b/donut/testing/fixtures.py
@@ -11,6 +11,7 @@ def client():
     donut.init("test")
     # Need to specify a server, since test_client doesn't do that for us.
     app.config["SERVER_NAME"] = "127.0.0.1"
+    app.config["JSONIFY_PRETTYPRINT_REGULAR"] = False
 
     # Establish an application context before running the tests.
     ctx = app.app_context()

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -1,3 +1,10 @@
 /* Test data / initial data */
 INSERT INTO members(uid, last_name, first_name, email)
     VALUES ('1957540', 'Qu', 'David', 'davidqu12345@gmail.com');
+
+INSERT INTO groups(group_id, group_name, type)
+    VALUES (1, 'Donut Devteam', '');
+
+INSERT INTO positions(group_id, pos_id, pos_name) VALUES
+    (1, 1, 'Head'),
+    (1, 2, 'Secretary');

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -1,0 +1,61 @@
+"""
+Tests donut/modules/groups/
+"""
+from donut.testing.fixtures import client
+from donut import app
+from donut.modules.groups import helpers
+from donut.modules.groups import routes
+
+group = {
+    "group_id": 1,
+    "group_name": "Donut Devteam",
+    "group_desc": None,
+    "type": ""
+}
+
+
+# Helpers
+def test_get_group_list_data(client):
+    assert helpers.get_group_list_data(["not_a_real_field"]) == "Invalid field"
+    assert helpers.get_group_list_data(["group_name"]) == [{
+        "group_name":
+        "Donut Devteam"
+    }]
+    groups = [group]
+    assert helpers.get_group_list_data() == groups
+    assert helpers.get_group_list_data(None, {"group_id": 1}) == groups
+    assert helpers.get_group_list_data(None, {"group_id": 2}) == []
+
+
+def test_get_group_positions_data(client):
+    assert helpers.get_group_positions(1) == [{
+        "pos_id": 1,
+        "pos_name": "Head"
+    }, {
+        "pos_id": 2,
+        "pos_name": "Secretary"
+    }]
+    assert helpers.get_group_positions(2) == []
+
+
+def test_get_group_data(client):
+    assert helpers.get_group_data(2) == {}
+    assert helpers.get_group_data(1, ["not_a_real_field"]) == "Invalid field"
+    assert helpers.get_group_data(1) == group
+    assert helpers.get_group_data(1, ["group_name"]) == {
+        "group_name": "Donut Devteam"
+    }
+
+
+# Test Routes
+# Difficult to test because query arguments are undefined outside Flask context
+# def test_get_groups_list(client):
+#     assert routes.get_groups_list() is not None
+
+
+def test_get_group_positions(client):
+    assert routes.get_group_positions(1) is not None
+
+
+def get_groups(client):
+    assert routes.get_groups(1) is not None


### PR DESCRIPTION
### Summary
Adds a `GET /1/groups/<int:group_id>/positions/` API that lists all positions with their ids and names for a given group. Also resets test database when tests are run.

### Test Plan
- Go to `http://localhost:9000/1/groups/1/positions/`
