### PR TITLE
Delete Position Holders Pill

### DIFF
--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -54,6 +54,7 @@ def get_group_positions(group_id):
         cursor.execute(query, [group_id])
         return list(cursor.fetchall())
 
+
 def get_direct_position_holders(pos_id):
     """
     Queries the database and returns a list of all members and their names

--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -54,6 +54,29 @@ def get_group_positions(group_id):
         cursor.execute(query, [group_id])
         return list(cursor.fetchall())
 
+def get_direct_position_holders(pos_id):
+    """
+    Queries the database and returns a list of all members and their names
+    that currently hold the position specified by the pos_id. This only
+    includes people that are directly holding the position as specified
+    by the position_holders table
+
+    Arguments:
+        pos_id: the position id to be queried
+    Returns:
+        results:    A list where each element describes a user who holds the
+                    position. Each element is a dict with key:value of
+                    columnname:columnvalue
+    """
+    fields = ["user_id", "first_name", "last_name", "start_date", "end_date"]
+    query = "SELECT " + ', '.join(fields) + " "
+    query += """FROM position_holders NATURAL JOIN members
+                WHERE pos_id =%s"""
+
+    with flask.g.pymysql_db.cursor() as cursor:
+        cursor.execute(query, [pos_id])
+        return cursor.fetchall()
+
 
 def get_position_holders(pos_id):
     """

--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -69,14 +69,12 @@ def get_direct_position_holders(pos_id):
                     position. Each element is a dict with key:value of
                     columnname:columnvalue
     """
-    fields = ["user_id", "first_name", "last_name", "start_date", "end_date"]
-    query = "SELECT " + ', '.join(fields) + " "
-    query += """FROM position_holders NATURAL JOIN members
-                WHERE pos_id =%s"""
+    query = """SELECT user_id, first_name, last_name, start_date, end_date
+            FROM position_holders NATURAL JOIN members WHERE pos_id = %s"""
 
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, [pos_id])
-        return cursor.fetchall()
+        return list(cursor.fetchall())
 
 
 def get_position_holders(pos_id):
@@ -265,7 +263,6 @@ def create_position_holder(pos_id, user_id, start_date, end_date):
     end_date) VALUES (%s, %s, %s, %s)"""
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(s, (pos_id, user_id, start_date, end_date))
-        cursor.close()
 
 
 def delete_position_holder(pos_id, user_id):

--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -63,7 +63,7 @@ def get_position_holders(pos_id):
     and Y is linked to X
 
     Arguments:
-        pos_id:     The position to look up -- may be a single int or a list of int's 
+        pos_id:     The position to look up -- may be a single int or a list of int's
 
     Returns:
         results:    A list where each element describes a user who holds the
@@ -85,13 +85,13 @@ def get_position_holders(pos_id):
 
 
 def get_positions_held(user_id):
-    ''' Returns a list of all position id's held (directly or indirectly) 
+    ''' Returns a list of all position id's held (directly or indirectly)
     by the given user. If no positions are found, [] is returned. '''
-    query = '''SELECT pos_id FROM position_holders ph 
+    query = '''SELECT pos_id FROM position_holders ph
                WHERE user_id = %s
-               UNION 
+               UNION
                SELECT pos_id FROM (
-               SELECT pos_id_to as pos_id FROM position_holders ph 
+               SELECT pos_id_to as pos_id FROM position_holders ph
                JOIN position_relations pr
                ON ph.pos_id = pr.pos_id_from WHERE user_id = %s
                ) sub'''
@@ -102,7 +102,7 @@ def get_positions_held(user_id):
 
 
 def get_position_id(group_name, position_name):
-    ''' Returns the position id associated with the given group name and 
+    ''' Returns the position id associated with the given group name and
     position name '''
     query = '''SELECT pos_id FROM positions WHERE pos_name = %s
     AND group_id = (SELECT min(group_id) FROM groups WHERE group_name = %s)'''
@@ -147,10 +147,10 @@ def get_group_data(group_id, fields=None):
 
 
 def get_position_data(fields=None):
-    """ 
+    """
     Queries database for all instances where an individual holds a position.
     This includes when person A directly holds position Y, or when person A
-    indirectly holds Y by holding position X and with 
+    indirectly holds Y by holding position X and with
     an entry in the position relation table that links position X to position Y.
 
     Arguments:
@@ -180,7 +180,7 @@ def get_position_data(fields=None):
         fields.remove("pos_id")
         fields.append("p.pos_id")
     query = "SELECT DISTINCT " + ', '.join(fields) + " "
-    query += """FROM positions p 
+    query += """FROM positions p
             LEFT JOIN position_relations pr ON p.pos_id=pr.pos_id_to
             INNER JOIN position_holders ph ON ph.pos_id=pr.pos_id_from
             OR ph.pos_id = p.pos_id NATURAL JOIN members NATURAL JOIN groups"""
@@ -237,10 +237,25 @@ def create_position_holder(pos_id, user_id, start_date, end_date):
         start_date: Starting date of the holding period, format is 'yyyy-mm-dd'
         end_date: end date of the hold period
     '''
-    s = """INSERT INTO position_holders (pos_id, user_id, start_date, 
+    s = """INSERT INTO position_holders (pos_id, user_id, start_date,
     end_date) VALUES (%s, %s, %s, %s)"""
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(s, (pos_id, user_id, start_date, end_date))
+        cursor.close()
+
+
+def delete_position_holder(pos_id, user_id):
+    '''
+    Removes a user from holding a position
+
+    Arguments:
+        pos_id: id of the position
+        user_id: user id of the person that is to be removed from the position
+    '''
+    s = "DELETE FROM position_holders WHERE pos_id = %s AND user_id = %s"
+    with flask.g.pymysql_db.cursor() as cursor:
+        cursor.execute(s, (pos_id, user_id))
+        cursor.close()
 
 
 def get_members_by_group(group_id):

--- a/donut/modules/groups/routes.py
+++ b/donut/modules/groups/routes.py
@@ -69,6 +69,12 @@ def get_group_members(group_id):
     return jsonify(helpers.get_members_by_group(group_id))
 
 
+@blueprint.route("/1/positions/<int:pos_id>/direct/", methods=["GET"])
+def get_direct_pos_holders(pos_id):
+    """GET /1/positions/<int:pos_id>/direct"""
+    return jsonify(helpers.get_direct_position_holders(pos_id))
+
+
 @blueprint.route("/1/positions/<int:pos_id>/", methods=["GET"])
 def get_pos_holders(pos_id):
     """GET /1/positions/<int:pos_id>/"""

--- a/donut/modules/groups/routes.py
+++ b/donut/modules/groups/routes.py
@@ -96,3 +96,15 @@ def create_pos_holder(pos_id):
                                    int(form["user_id"]), form["start_date"],
                                    form["end_date"])
     return jsonify({'success': True})
+
+
+@blueprint.route("/1/positions/<int:pos_id>/delete/", methods=["POST"])
+def delete_pos_holder(pos_id):
+    form = flask.request.form
+    validations = [
+        validate_exists(form, "user_id") and validate_int(form["user_id"]),
+    ]
+    if not all(validations):
+        return jsonify({'success': False})
+    helpers.delete_position_holder(pos_id, form["user_id"])
+    return jsonify({'success': True})

--- a/donut/static/js/groups/positions.js
+++ b/donut/static/js/groups/positions.js
@@ -182,7 +182,6 @@ function formatDate(dateString) {
 function posIdDelHoldChange() {
     var positionIndex = $('#posIdDelHold').val();
     var url = '/1/positions/' + positionIndex + '/direct/';
-    debugger;
     $.ajax({
         url: url,
         success: function(data){
@@ -262,6 +261,22 @@ $(document).ready(function() {
             }
         });
     });
+    $('#submitDelPosHoldBtn').click(function(e) {
+        e.preventDefault();
+        $.ajax({
+            type: 'POST',
+            url: '/1/positions/' + $("#posIdDelHold").val() + '/delete/',
+            data: $("#deleteHoldForm").serialize(),
+            success: function(data) {
+                if(data.success) {
+                    setUpForms();
+                    alert("Deleted Position!");
+                } else {
+                    alert("Something went Wrong");
+                }
+            }
+        });
+    });
 });
 
 /*
@@ -269,7 +284,8 @@ $(document).ready(function() {
  */
 function setUpForms() {
     $('#posDelete').trigger("reset");
-    $('#holdForm').trigger("reset")
+    $('#holdForm').trigger("reset");
+    $('#deleteHoldForm').trigger("reset");
     $('#position').find('option')
                   .remove()
                   .end()
@@ -278,5 +294,14 @@ function setUpForms() {
                     .remove()
                     .end()
                     .append('<option>Select a Position</option>');
+    $('#posIdDelHold').find('option')
+                    .remove()
+                    .end()
+                    .append('<option>Pick a Position</option>');
+    $('#delName').find('option')
+                    .remove()
+                    .end()
+                    .append('<option>Pick a Holder</option>');
+
 
 }

--- a/donut/static/js/groups/positions.js
+++ b/donut/static/js/groups/positions.js
@@ -26,6 +26,7 @@ function populateAdminGroups(approvedGroupIds, approvedGroupNames) {
         $('#groupCreate option:last').after(newOption);
         $('#groupDel option:last').after(newOption);
         $('#groupPosHold option:last').after(newOption);
+        $('#groupDelPosHold option:last').after(newOption);
     }
 }
 
@@ -152,6 +153,42 @@ function groupPosHoldChange() {
 }
 
 /*
+ * Called when a group is selected for the "delete position holder" tab.
+ * Queries for all positions associated with the group
+ */
+function groupDelPosHoldChange() {
+    var groupIndex = $('#groupDelPosHold').val();
+    $('#posIdDelHold').find('option').remove();
+    $('#posIdDelHold').append('<option> Pick a position </option>');
+    populateListOfPositions(groupIndex, '#posIdDelHold');
+}
+
+/*
+ * Called when a position is selected for the "delete position holder" tab.
+ * Queries for all holders of that position and fills in the name list
+ */
+function posIdDelHoldChange() {
+    var positionIndex = $('#posIdDelHold').val();
+    var url = '/1/positions/' + positionIndex + '/direct/';
+    console.log("HERE");
+    debugger;
+    $.ajax({
+        url: url,
+        success: function(data){
+            console.log(data);
+            $('#delName').find('option').remove();
+            for (var i = 0; i < data.length; i++) {
+                var newOption = '<option value=' + data[i].user_id + '>' +
+                    data[i].first_name + ' ' + data[i].last_name +
+                    '(' + data[i].start_date + " to " + data[i].end_date +
+                    ')</option>';
+                $('#delName').append(newOption);
+            }
+        }
+    });
+}
+
+/*
  * This method takes in a group id and a select element id and populates
  * the select element with a list of options representing all positions
  * associated with the group
@@ -169,6 +206,7 @@ function populateListOfPositions(groupIndex, posSelectId) {
         }
     });
 }
+
 
 $(document).ready(function() {
     // Setting up triggers for administration tasks

--- a/donut/static/js/groups/positions.js
+++ b/donut/static/js/groups/positions.js
@@ -164,24 +164,34 @@ function groupDelPosHoldChange() {
 }
 
 /*
+ * Converts a dateString to a more readable format
+ */
+function formatDate(dateString) {
+    if (dateString == null) {
+        return null;
+    }
+    var d = new Date(dateString);
+    var options = { weekday: 'long', year: 'numeric', month: 'long',
+        day: 'numeric' };
+    return d.toLocaleDateString('en-US', options);
+}
+/*
  * Called when a position is selected for the "delete position holder" tab.
  * Queries for all holders of that position and fills in the name list
  */
 function posIdDelHoldChange() {
     var positionIndex = $('#posIdDelHold').val();
     var url = '/1/positions/' + positionIndex + '/direct/';
-    console.log("HERE");
     debugger;
     $.ajax({
         url: url,
         success: function(data){
-            console.log(data);
             $('#delName').find('option').remove();
             for (var i = 0; i < data.length; i++) {
                 var newOption = '<option value=' + data[i].user_id + '>' +
                     data[i].first_name + ' ' + data[i].last_name +
-                    '(' + data[i].start_date + " to " + data[i].end_date +
-                    ')</option>';
+                    ' (' + formatDate(data[i].start_date) + " to " +
+                    formatDate(data[i].end_date) + ')</option>';
                 $('#delName').append(newOption);
             }
         }

--- a/donut/static/js/groups/positions.js
+++ b/donut/static/js/groups/positions.js
@@ -23,6 +23,8 @@ function populateAdminGroups(approvedGroupIds, approvedGroupNames) {
     for (var i = 0; i < approvedGroupIds.length; i++) {
         var newOption = '<option value=' + approvedGroupIds[i] + '>' +
             approvedGroupNames[i] + '</option>'
+        // TODO: create a new class .group-select and put all of these
+        // elements in them.
         $('#groupCreate option:last').after(newOption);
         $('#groupDel option:last').after(newOption);
         $('#groupPosHold option:last').after(newOption);
@@ -189,7 +191,7 @@ function posIdDelHoldChange() {
             for (var i = 0; i < data.length; i++) {
                 var newOption = '<option value=' + data[i].user_id + '>' +
                     data[i].first_name + ' ' + data[i].last_name +
-                    ' (' + formatDate(data[i].start_date) + " to " +
+                    ' (' + formatDate(data[i].start_date) + ' to ' +
                     formatDate(data[i].end_date) + ')</option>';
                 $('#delName').append(newOption);
             }
@@ -220,7 +222,6 @@ function populateListOfPositions(groupIndex, posSelectId) {
 $(document).ready(function() {
     // Setting up triggers for administration tasks
     $('#submitPosBtn').click(function(e) {
-        e.preventDefault();
         $.ajax({
             type: 'POST',
             url: '/1/positions/',
@@ -234,7 +235,6 @@ $(document).ready(function() {
         });
     });
     $('#delPosBtn').click(function(e) {
-        e.preventDefault();
         $.ajax({
             type: 'POST',
             url: '/1/positions/delete/',
@@ -248,7 +248,6 @@ $(document).ready(function() {
         });
     });
     $('#submitPosHoldBtn').click(function(e) {
-        e.preventDefault();
         $.ajax({
             type: 'POST',
             url: '/1/positions/' + $("#posIdHold").val() + '/',
@@ -262,7 +261,6 @@ $(document).ready(function() {
         });
     });
     $('#submitDelPosHoldBtn').click(function(e) {
-        e.preventDefault();
         $.ajax({
             type: 'POST',
             url: '/1/positions/' + $("#posIdDelHold").val() + '/delete/',

--- a/donut/templates/campus_positions.html
+++ b/donut/templates/campus_positions.html
@@ -151,11 +151,10 @@
                         <div class='form-group'>
                             <label class="control-label col-sm-2" for='delName'>
                                 Name: </label>
-                            <select class='form-control' id='delName' name='name'>
+                            <select class='form-control' id='delName' name='user_id'>
                                 <option> Pick a holder </option>
                             </select>
                         </div>
-                        <input type="hidden" id="del_user_id" name="user_id">
                         <button id="submitDelPosHoldBtn" class="btn btn-default">
                             Delete Holder
                         </button>

--- a/donut/templates/campus_positions.html
+++ b/donut/templates/campus_positions.html
@@ -45,6 +45,9 @@
                 <li>
                     <a data-toggle="pill" href="#assignHold">Assign a Position Holder</a>
                 </li>
+                <li>
+                    <a data-toggle="pill" href="#deleteHold">Delete a Position Holder</a>
+                </li>
             </ul>
             <div class="tab-content">
                 <div id="createPos" class="tab-pane fade in active">
@@ -123,6 +126,37 @@
                             <input id='end_date' type='date' name='end_date'/>
                         </div>
                         <button id="submitPosHoldBtn" class="btn btn-default">
+                            Submit
+                        </button>
+                    </form>
+                </div>
+                <div id="deleteHold" class="tab-pane fade in">
+                    <form id="deleteHoldForm">
+                        <div class="form-group">
+                            <label class="control-label col-sm-2" for="groupDelPosHold">
+                                Group Name:</label>
+                            <select class="form-control" id="groupDelPosHold" 
+                                    onchange="groupDelPosHoldChange()" name="group_id"> 
+                                <option> Select a Group </option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2" for="posIdDelHold">
+                                Position: </label>
+                            <select class="form-control" id="posIdDelHold" 
+                                    onchange="posIdDelHoldChange()" name="pos_id">
+                                <option> Pick a position </option>
+                            </select>
+                        </div>
+                        <div class='form-group'>
+                            <label class="control-label col-sm-2" for='delName'>
+                                Name: </label>
+                            <select class='form-control' id='delName' name='name'>
+                                <option> Pick a holder </option>
+                            </select>
+                        </div>
+                        <input type="hidden" id="del_user_id" name="user_id">
+                        <button id="submitDelPosHoldBtn" class="btn btn-default">
                             Submit
                         </button>
                     </form>

--- a/donut/templates/campus_positions.html
+++ b/donut/templates/campus_positions.html
@@ -157,7 +157,7 @@
                         </div>
                         <input type="hidden" id="del_user_id" name="user_id">
                         <button id="submitDelPosHoldBtn" class="btn btn-default">
-                            Submit
+                            Delete Holder
                         </button>
                     </form>
                 </div>

--- a/donut/templates/campus_positions.html
+++ b/donut/templates/campus_positions.html
@@ -66,7 +66,7 @@
                             <input class="form-control" id="posName" 
                                                             name="pos_name">
                         </div>
-                        <button id="submitPosBtn" class="btn">
+                        <button type='button' id="submitPosBtn" class="btn">
                             Submit
                         </button>
                     </form>
@@ -88,7 +88,9 @@
                                 <option> Pick a position </option>
                             </select>
                         </div>
-                        <button id="delPosBtn" class="btn">Submit</button>
+                        <button type='button' id="delPosBtn" class="btn">
+                            Submit
+                        </button>
                     </form>     
                 </div>
                 <div id="assignHold" class="tab-pane fade in">
@@ -125,7 +127,7 @@
                             <label for='end_date'> End Date: </label>
                             <input id='end_date' type='date' name='end_date'/>
                         </div>
-                        <button id="submitPosHoldBtn" class="btn btn-default">
+                        <button type='button' id="submitPosHoldBtn" class="btn btn-default">
                             Submit
                         </button>
                     </form>
@@ -134,7 +136,8 @@
                     <form id="deleteHoldForm">
                         <div class="form-group">
                             <label class="control-label col-sm-2" for="groupDelPosHold">
-                                Group Name:</label>
+                                Group Name:
+                            </label>
                             <select class="form-control" id="groupDelPosHold" 
                                     onchange="groupDelPosHoldChange()" name="group_id"> 
                                 <option> Select a Group </option>
@@ -155,7 +158,7 @@
                                 <option> Pick a holder </option>
                             </select>
                         </div>
-                        <button id="submitDelPosHoldBtn" class="btn btn-default">
+                        <button type='button' id="submitDelPosHoldBtn" class="btn btn-default">
                             Delete Holder
                         </button>
                     </form>

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -53,7 +53,6 @@ def test_get_group_positions_data(client):
 
 def test_get_direct_position_holders(client):
     res = helpers.get_direct_position_holders(5)
-    assert len(res) == 1
     assert set(row['first_name'] for row in res) == set(['Sean'])
 
     res = helpers.get_direct_position_holders(1)

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -50,6 +50,7 @@ def test_get_group_positions_data(client):
     }]
     assert helpers.get_group_positions(4) == []
 
+
 def test_get_direct_position_holders(client):
     res = helpers.get_direct_position_holders(5)
     assert len(res) == 1
@@ -73,7 +74,6 @@ def test_get_position_holders(client):
     assert len(res) == 3
     assert set(row['first_name']
                for row in res) == set(['Robert', 'Sean', 'David'])
-
 
 
 def test_get_positions_held(client):

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -159,6 +159,24 @@ def test_create_pos_holders(client):
     }]
 
 
+def test_delete_pos_holders(client):
+    helpers.create_position_holder(2, 1, "2018-02-22", "2019-02-22")
+    assert helpers.get_position_holders(2) == [{
+        "user_id":
+        1,
+        "first_name":
+        "David",
+        "last_name":
+        "Qu",
+        "start_date":
+        datetime.date(2018, 2, 22),
+        "end_date":
+        datetime.date(2019, 2, 22)
+    }]
+    helpers.delete_position_holder(2, 1)
+    assert helpers.get_position_holders(2) == ()
+
+
 # Test Routes
 # Difficult to test because query arguments are undefined outside Flask context
 # def test_get_groups_list(client):

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -50,6 +50,15 @@ def test_get_group_positions_data(client):
     }]
     assert helpers.get_group_positions(4) == []
 
+def test_get_direct_position_holders(client):
+    res = helpers.get_direct_position_holders(5)
+    assert len(res) == 1
+    assert set(row['first_name'] for row in res) == set(['Sean'])
+
+    res = helpers.get_direct_position_holders(1)
+    assert len(res) == 2
+    assert set(row['first_name'] for row in res) == set(['Robert', 'David'])
+
 
 def test_get_position_holders(client):
     res = helpers.get_position_holders(5)
@@ -64,6 +73,7 @@ def test_get_position_holders(client):
     assert len(res) == 3
     assert set(row['first_name']
                for row in res) == set(['Robert', 'Sean', 'David'])
+
 
 
 def test_get_positions_held(client):


### PR DESCRIPTION
### Summary
- Added a delete position holders pill on the positions tab
- Added new 'get_direct_holders' helper function
- Added /1/positions/<int>/delete POST endpoint

### Test Plan
- Added test case for helper function
- Manual e2e test:
-- Add new user to hold a position (with the right time frame)
-- Reload page to see he has been added 
-- Navigate to remove position holder tab and remove him
-- See that he is no longer there
