### PR TITLE
Don't pad list group

### DIFF
--- a/donut/static/css/style.css
+++ b/donut/static/css/style.css
@@ -256,7 +256,7 @@ input[type=checkbox], input[type=radio] {
 }
 
 /* For better mobile and desktop positioning of lists. */
-.jumbotron ul {
+.jumbotron ul:not(.list-group) {
   padding: 10px;
 }
 
@@ -330,7 +330,7 @@ input[type=checkbox], input[type=radio] {
   text-align: right;
 }
 
-/* Creates a row-like element. These are intended to stack atop one another 
+/* Creates a row-like element. These are intended to stack atop one another
  * vertically.
  */
 .row {
@@ -367,7 +367,7 @@ input[type=checkbox], input[type=radio] {
  * should not be used for general styling or anything of the like. Odds are, *
  * you won't need them for anything!                                         */
 /*****************************************************************************/
- 
+
 
 /* Content needs to span the width of its parent. */
 #content {
@@ -550,7 +550,7 @@ input[type=checkbox], input[type=radio] {
   #copyright {
     font-size: 1vh;
     text-align: left;
- } 
+ }
 }
 
 /* END MOBILE CSS */


### PR DESCRIPTION
This style addition was making the `ul.list-group`s that were being used in the directory look really strange:
![old-padding](https://user-images.githubusercontent.com/4256376/49555756-dddfc980-f8b5-11e8-959f-a985deb3ee0a.png)
vs.
![new-padding](https://user-images.githubusercontent.com/4256376/49555755-dddfc980-f8b5-11e8-881e-f90d17cbc353.png)

