### PR TITLE
Avoid comparing numbers to strings

### DIFF
--- a/donut/modules/directory_search/helpers.py
+++ b/donut/modules/directory_search/helpers.py
@@ -164,8 +164,11 @@ def execute_search(**kwargs):
         return cursor.fetchall()
 
 
-def members_unique_values(field):
-    query = 'SELECT DISTINCT ' + field + ' FROM members WHERE ' + field + ' IS NOT NULL AND ' + field + '!= "" ORDER BY ' + field
+def members_unique_values(field, string):
+    query = 'SELECT DISTINCT ' + field + ' FROM members WHERE ' + field + ' IS NOT NULL'
+    if string:
+        query += ' AND LENGTH(TRIM(' + field + '))'
+    query += ' ORDER BY ' + field
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query)
         return [member[field] for member in cursor.fetchall()]
@@ -193,8 +196,8 @@ def get_residences():
 
 
 def get_grad_years():
-    return members_unique_values('graduation_year')
+    return members_unique_values('graduation_year', False)
 
 
 def get_states():
-    return members_unique_values('state')
+    return members_unique_values('state', True)


### PR DESCRIPTION
Fixed these warnings in the test output, which were due to `members.graduation_year` being compared to `''`:
```
tests/modules/directory_search/test_directory_search.py::test_value_lists
  /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/pymysql/cursors.py:323: Warning: (1292, "Truncated incorrect DOUBLE value: ''")
    self._do_get_result()
tests/modules/directory_search/test_directory_search.py::test_search_page
  /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/pymysql/cursors.py:323: Warning: (1292, "Truncated incorrect DOUBLE value: ''")
    self._do_get_result()
```