### PR TITLE
Restrict unauthenticated access to directory and marketplace to Caltech campus

### DIFF
--- a/donut/__init__.py
+++ b/donut/__init__.py
@@ -58,6 +58,7 @@ def init(environment_name):
     app.config["DB_URI"] = environment.db_uri
     app.config["DEBUG"] = environment.debug
     app.config["SECRET_KEY"] = environment.secret_key
+    app.config["RESTRICTED_IPS"] = environment.restricted_ips
     app.config["DB_USER"] = environment.db_user
     app.config["DB_PASSWORD"] = environment.db_password
     app.config["DB_NAME"] = environment.db_name

--- a/donut/default_config.py
+++ b/donut/default_config.py
@@ -16,4 +16,4 @@ TEST = environment.Environment(
         "id": "b579f690cacf867",
         "secret": "****************************************"
     },
-    restricted_ips=r"^12\.34\.")
+    restricted_ips=r"127\.0\.0\.1")

--- a/donut/default_config.py
+++ b/donut/default_config.py
@@ -15,4 +15,5 @@ TEST = environment.Environment(
     imgur_api={
         "id": "b579f690cacf867",
         "secret": "****************************************"
-    })
+    },
+    restricted_ips=r"^12\.34\.")

--- a/donut/environment.py
+++ b/donut/environment.py
@@ -10,10 +10,11 @@ class Environment(object):
     testing: bool for whether or not testing mode should be enabled.
     secret_key: secret key for session cookie.
     imgur_api: a map {"id": <imgur_id>, "secret": <imgur_secret>}
+    restricted_ips: a regular expression to match on-campus IP addresses
   """
 
     def __init__(self, db_hostname, db_name, db_user, db_password, debug,
-                 testing, secret_key, imgur_api):
+                 testing, secret_key, imgur_api, restricted_ips):
         self.db_hostname = db_hostname
         self.db_name = db_name
         self.db_user = db_user
@@ -21,6 +22,7 @@ class Environment(object):
         self.debug = debug
         self.secret_key = secret_key
         self.imgur_api = imgur_api
+        self.restricted_ips = restricted_ips
 
     @property
     def db_uri(self):

--- a/donut/modules/directory_search/helpers.py
+++ b/donut/modules/directory_search/helpers.py
@@ -16,7 +16,7 @@ def get_hidden_fields(viewer_name, viewee_id):
         if is_me or check_permission(
                 viewer_name, Directory_Permissions.HIDDEN_SEARCH_FIELDS):
             return set()
-    return set(['uid', 'birthday', 'phone_string'])
+    return set(['uid', 'birthday', 'phone_string', 'hometown_string'])
 
 
 def get_user(user_id):
@@ -157,9 +157,6 @@ def execute_search(**kwargs):
     if kwargs['grad_year']:
         query += ' AND graduation_year = %s'
         substitution_arguments.append(kwargs['grad_year'])
-    if kwargs['state']:
-        query += ' AND state = %s'
-        substitution_arguments.append(kwargs['state'])
     query += ' ORDER BY LOWER(last_name), LOWER(full_name)'
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, substitution_arguments)
@@ -199,7 +196,3 @@ def get_residences():
 
 def get_grad_years():
     return members_unique_values('graduation_year', False)
-
-
-def get_states():
-    return members_unique_values('state', True)

--- a/donut/modules/directory_search/routes.py
+++ b/donut/modules/directory_search/routes.py
@@ -17,8 +17,7 @@ def directory_search():
         houses=helpers.get_houses(),
         options=helpers.get_options(),
         residences=helpers.get_residences(),
-        grad_years=helpers.get_grad_years(),
-        states=helpers.get_states())
+        grad_years=helpers.get_grad_years())
 
 
 @blueprint.route('/1/users/<int:user_id>')
@@ -88,14 +87,12 @@ def search():
         grad_year = int(grad_year)
     else:
         grad_year = None
-    state = form['state'] or None
     users = helpers.execute_search(
         name=name,
         house_id=house_id,
         option_id=option_id,
         building_id=building_id,
         grad_year=grad_year,
-        state=state,
         username=form['username'],
         email=form['email'])
     if len(users) == 1:  #1 result

--- a/donut/modules/directory_search/routes.py
+++ b/donut/modules/directory_search/routes.py
@@ -3,12 +3,15 @@ import json
 import mimetypes
 from flask import jsonify, redirect
 
-from donut.auth_utils import get_user_id
+from donut.auth_utils import get_user_id, is_caltech_user, login_redirect
 from donut.modules.directory_search import blueprint, helpers
 
 
 @blueprint.route('/directory')
 def directory_search():
+    if not is_caltech_user():
+        return login_redirect()
+
     return flask.render_template(
         'directory_search.html',
         houses=helpers.get_houses(),
@@ -20,6 +23,9 @@ def directory_search():
 
 @blueprint.route('/1/users/<int:user_id>')
 def view_user(user_id):
+    if not is_caltech_user():
+        return login_redirect()
+
     user = helpers.get_user(user_id)
     is_me = 'username' in flask.session and get_user_id(
         flask.session['username']) == user_id
@@ -35,6 +41,9 @@ def view_user(user_id):
 
 @blueprint.route('/1/users/<int:user_id>/image')
 def get_image(user_id):
+    if not is_caltech_user():
+        flask.abort(401)
+
     extension, image = helpers.get_image(user_id)
     response = flask.make_response(image)
     response.headers.set('Content-Type',
@@ -44,11 +53,17 @@ def get_image(user_id):
 
 @blueprint.route('/1/users/search/<name_query>')
 def search_by_name(name_query):
+    if not is_caltech_user():
+        flask.abort(401)
+
     return jsonify(helpers.get_users_by_name_query(name_query))
 
 
 @blueprint.route('/1/users', methods=['POST'])
 def search():
+    if not is_caltech_user():
+        flask.abort(401)
+
     form = flask.request.form
     name = form['name']
     if name.strip() == '':

--- a/donut/modules/directory_search/templates/directory_search.html
+++ b/donut/modules/directory_search/templates/directory_search.html
@@ -46,15 +46,6 @@
 				</select>
 			</div>
 			<div class='form-group'>
-				<label for='state'>Home state</label>
-				<select class='form-control' id='state' name='state'>
-					<option value=''>Any state</option>
-					{% for state in states %}
-						<option>{{ state }}</option>
-					{% endfor %}
-				</select>
-			</div>
-			<div class='form-group'>
 				<label for='username'>Username</label>
 				<input class='form-control' id='username' name='username' />
 			</div>

--- a/donut/modules/marketplace/helpers.py
+++ b/donut/modules/marketplace/helpers.py
@@ -3,7 +3,6 @@ import re
 
 from donut.modules.core.helpers import get_member_data, get_name_and_email
 from donut.auth_utils import get_user_id, check_permission
-from donut.default_permissions import Permissions
 
 # taken from donut-legacy, which was apparently taken from a CS11
 # C++ assignment by dkong
@@ -74,15 +73,17 @@ def can_manage(item):
     Item may be {'user_id': int} or an item_id.
     """
 
+    username = flask.session.get('username')
+    if not username:
+        # Must be logged in to manage
+        return False
+
     user_id = table_fetch(
         'marketplace_items',
         one=True,
         fields=('user_id', ),
         attrs={'item_id': item}) if type(item) == int else item['user_id']
-
-    username = flask.session.get('username')
-    return username and (get_user_id(username) == user_id
-                         or check_permission(username, Permissions.ADMIN))
+    return get_user_id(username) == user_id or check_permission(username, None)
 
 
 ###############

--- a/donut/modules/marketplace/templates/requires_login.html
+++ b/donut/modules/marketplace/templates/requires_login.html
@@ -1,9 +1,0 @@
-{% extends "layout.html" %}
-{% block page %}
-
-<p class="login-info">
-    This page requires you to login with your username and password.
-    Login <a href="{{ url_for('auth.login') }}">here</a> and you'll be redirected.
-</p>
-
-{% endblock %}

--- a/tests/modules/directory_search/test_directory_search.py
+++ b/tests/modules/directory_search/test_directory_search.py
@@ -135,8 +135,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set([1, 2, 3])
+                   grad_year=None)) == set([1, 2, 3])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='san',
@@ -145,8 +144,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set([3])
+                   grad_year=None)) == set([3])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -155,8 +153,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set()
+                   grad_year=None)) == set()
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -165,8 +162,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set([1])
+                   grad_year=None)) == set([1])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -175,8 +171,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set()
+                   grad_year=None)) == set()
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -185,8 +180,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set([2, 3])
+                   grad_year=None)) == set([2, 3])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -195,8 +189,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set()
+                   grad_year=None)) == set()
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -205,8 +198,7 @@ def test_search(client):
                    house_id=2,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set([3])
+                   grad_year=None)) == set([3])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -215,8 +207,7 @@ def test_search(client):
                    house_id=100,
                    option_id=None,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set()
+                   grad_year=None)) == set()
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -225,8 +216,7 @@ def test_search(client):
                    house_id=None,
                    option_id=1,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set([3])
+                   grad_year=None)) == set([3])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -235,8 +225,7 @@ def test_search(client):
                    house_id=None,
                    option_id=2,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set([3])
+                   grad_year=None)) == set([3])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -245,8 +234,7 @@ def test_search(client):
                    house_id=None,
                    option_id=100,
                    building_id=None,
-                   grad_year=None,
-                   state=None)) == set()
+                   grad_year=None)) == set()
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -255,8 +243,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=1,
-                   grad_year=None,
-                   state=None)) == set([3])
+                   grad_year=None)) == set([3])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -265,8 +252,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=10,
-                   grad_year=None,
-                   state=None)) == set()
+                   grad_year=None)) == set()
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -275,8 +261,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=2021,
-                   state=None)) == set([3])
+                   grad_year=2021)) == set([3])
     assert set(user['user_id']
                for user in helpers.execute_search(
                    email='',
@@ -285,28 +270,7 @@ def test_search(client):
                    house_id=None,
                    option_id=None,
                    building_id=None,
-                   grad_year=2020,
-                   state=None)) == set()
-    assert set(user['user_id']
-               for user in helpers.execute_search(
-                   email='',
-                   username='',
-                   name=None,
-                   house_id=None,
-                   option_id=None,
-                   building_id=None,
-                   grad_year=None,
-                   state='MA')) == set([3])
-    assert set(user['user_id']
-               for user in helpers.execute_search(
-                   email='',
-                   username='',
-                   name=None,
-                   house_id=None,
-                   option_id=None,
-                   building_id=None,
-                   grad_year=None,
-                   state='CA')) == set()
+                   grad_year=2020)) == set()
 
 
 def test_value_lists(client):
@@ -322,7 +286,6 @@ def test_value_lists(client):
         'option_name': 'MechE'
     }]
     assert helpers.get_grad_years() == [2021]
-    assert helpers.get_states() == ['MA']
 
 
 def test_preferred_name(client):
@@ -415,7 +378,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -428,7 +390,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -443,7 +404,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -458,7 +418,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -471,7 +430,6 @@ def test_search(client):
             'option': '1',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -486,7 +444,6 @@ def test_search(client):
             'option': '100',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -499,7 +456,6 @@ def test_search(client):
             'option': '',
             'residence': '1',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -514,7 +470,6 @@ def test_search(client):
             'option': '',
             'residence': '100',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -527,7 +482,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '2021',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -542,7 +496,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '2019',
-            'state': '',
             'username': '',
             'email': ''
         })
@@ -555,35 +508,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '',
-            'state': 'MA',
-            'username': '',
-            'email': ''
-        })
-    assert res.status_code == 302
-    assert res.headers['location'] == flask.url_for(
-        'directory_search.view_user', user_id=3)
-    res = client.post(
-        flask.url_for('directory_search.search'),
-        data={
-            'name': '',
-            'house': '',
-            'option': '',
-            'residence': '',
-            'graduation': '',
-            'state': 'IA',
-            'username': '',
-            'email': ''
-        })
-    assert res.status_code == 200  #no results
-    res = client.post(
-        flask.url_for('directory_search.search'),
-        data={
-            'name': '',
-            'house': '',
-            'option': '',
-            'residence': '',
-            'graduation': '',
-            'state': '',
             'username': 'qu',
             'email': ''
         })
@@ -598,7 +522,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': 'abc',
             'email': ''
         })
@@ -611,7 +534,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': 'reng'
         })
@@ -626,7 +548,6 @@ def test_search(client):
             'option': '',
             'residence': '',
             'graduation': '',
-            'state': '',
             'username': '',
             'email': 'xyz'
         })

--- a/tests/modules/marketplace/test_marketplace_routes.py
+++ b/tests/modules/marketplace/test_marketplace_routes.py
@@ -45,8 +45,8 @@ def test_marketplace_view_item(client):
 
 def test_marketplace_manage(client):
     rv = client.get(flask.url_for('marketplace.manage'))
-    assert rv.status_code == 200
-    assert b'This page requires you to login' in rv.data
+    assert rv.status_code == 302
+    assert rv.location == flask.url_for('auth.login')
 
     with client.session_transaction() as sess:
         sess['username'] = 'csander'
@@ -98,8 +98,8 @@ def test_marketplace_manage(client):
 
 def test_marketplace_sell(client):
     rv = client.get(flask.url_for('marketplace.sell'))
-    assert rv.status_code == 200
-    assert b'This page requires you to login' in rv.data
+    assert rv.status_code == 302
+    assert rv.location == flask.url_for('auth.login')
 
     with client.session_transaction() as sess:
         sess['username'] = 'csander'


### PR DESCRIPTION
### Summary
- All directory pages and marketplace pages (except the marketplace homepage) now require the user to be logged in or on Caltech internet
- Removed the ability to search the directory by hometown and stopped showing hometown on info page
- Using `login_redirect()` for marketplace rather than duplicating this functionality on a separate page

### Test Plan
- I tried visiting all the protected pages on and off the Caltech network
