### PR TITLE
Lower werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cov-core==1.15.0
 coverage==3.7.1
+werkzeug==0.16.*
 Flask==1.0.2
 flask_bootstrap==3.3.7.0
 itsdangerous==0.24


### PR DESCRIPTION
### Summary
- I think flask bumped up the werkzeug version since 1.0 was just released, and now secure_filename is in werkzeug.util. Not sure if we should also bump up the version (by renaming) or just cap things at 0.16.x?

### Test Plan
- make test on travis is happy
