### PR TITLE
Support ties in election rankings and add a surveys permission

### DIFF
--- a/donut/auth_utils.py
+++ b/donut/auth_utils.py
@@ -325,6 +325,7 @@ def get_permissions(username):
     user_id = get_user_id(username)
     if not user_id: return set()
     positions = groups.get_positions_held(user_id)
+    if not positions: return set()
     query = """
     SELECT permission_id FROM position_permissions WHERE pos_id in
     (%s)""" % (', '.join(['%s'] * len(positions)))

--- a/donut/modules/voting/helpers.py
+++ b/donut/modules/voting/helpers.py
@@ -16,8 +16,6 @@ AM_OR_PM = set(['A', 'P'])
 YYYY_MM_DD = '%Y-%m-%d'
 NO = 'NO'
 ALREADY_COMPLETED = 'Already completed'
-# The number of results to list for elected positions
-WINNERS_TO_LIST = 3
 
 
 def get_groups():
@@ -431,5 +429,5 @@ def get_results(survey_id):
         elif question_type == question_types['Checkboxes']:
             question['results'] = Counter(chain(*responses)).most_common()
         elif question_type == question_types['Elected position']:
-            question['results'] = winners(responses)[:WINNERS_TO_LIST]
+            question['results'] = winners(responses)
     return questions

--- a/donut/modules/voting/permissions.py
+++ b/donut/modules/voting/permissions.py
@@ -1,0 +1,6 @@
+from enum import IntEnum
+
+
+class Permissions(IntEnum):
+    # The permission_id for creating surveys
+    SURVEYS = 33

--- a/donut/modules/voting/ranked_pairs.py
+++ b/donut/modules/voting/ranked_pairs.py
@@ -35,9 +35,9 @@ def winners(responses):
 
     possible_pairs = sorted(tallies, key=tally_ranking)
     # Vertices reachable from A in win graph
-    lower = {A: set([A]) for A in all_candidates}
+    lower = {A: set((A, )) for A in all_candidates}
     # Vertices A is reachable from in win graph
-    higher = {A: set([A]) for A in all_candidates}
+    higher = {A: set((A, )) for A in all_candidates}
     for A, B in possible_pairs:
         if A not in lower[B]:  # if we don't already have B > A, set A > B
             for s in higher[A]:  #     if s > ... > A

--- a/donut/modules/voting/templates/list_surveys.html
+++ b/donut/modules/voting/templates/list_surveys.html
@@ -2,14 +2,16 @@
 {% block page %}
   <div class='row'>
     <div class='jumbotron col-md-8 col-md-offset-2' id='main'>
-      <div class='btn-group'>
-        <a href='{{ url_for("voting.make_survey_form") }}' class='btn btn-default'>
-          New Survey
-        </a>
-        <a href='{{ url_for("voting.my_surveys") }}' class='btn btn-default'>
-          My Surveys
-        </a>
-      </div>
+      {% if has_surveys_perm %}
+        <div class='btn-group'>
+          <a href='{{ url_for("voting.make_survey_form") }}' class='btn btn-default'>
+            New Survey
+          </a>
+          <a href='{{ url_for("voting.my_surveys") }}' class='btn btn-default'>
+            My Surveys
+          </a>
+        </div>
+      {% endif %}
 
       <div class='row'>
         <div class='col-md-6'>

--- a/donut/modules/voting/templates/my-response.html
+++ b/donut/modules/voting/templates/my-response.html
@@ -44,12 +44,13 @@
             <div>{{ question['response'] }}</div>
           {% elif question['type'] == question_types['Elected position'] %}
             <ul class="list-group">
-              {% for vote in question['response'] %}
-                <li class="list-group-item">
-                    <div>{{ vote }}</div>
-                </li>
-              {% endfor %}
-              {% if not question['response'] %}
+              {% if question['response'] %}
+                {% for vote in question['response'] %}
+                  <li class="list-group-item">
+                      <div>{{ loop.index }}. {{ ', '.join(vote) }}</div>
+                  </li>
+                {% endfor %}
+              {% else %}
                 <li class="list-group-item">
                     <div>Abstained</div>
                 </li>

--- a/donut/modules/voting/templates/results.html
+++ b/donut/modules/voting/templates/results.html
@@ -100,8 +100,8 @@
             <ul class="list-group">
               {% for response in question['responses'] %}
                 <li class="list-group-item">
-                  {% for vote in response %}
-                    <div>{{ vote }}</div>
+                  {% for rank in response %}
+                    <div>{{ ', '.join(rank) }}</div>
                   {% endfor %}
                 </li>
               {% endfor %}

--- a/donut/modules/voting/templates/take.html
+++ b/donut/modules/voting/templates/take.html
@@ -97,18 +97,16 @@
     }
   }
   function moveUp() {
-    var $this = $(this)
-    var rankCell = $this.closest('td')
-    var rank = rankCell.closest('tr')
+    var rankCell = $(this).closest('td')
+    var rank = rankCell.parent()
     var previousRank = rank.prev()
     if (!previousRank.length) previousRank = $('<tr>').insertBefore(rank)
     previousRank.append(rankCell)
     if (rank.is(':empty')) rank.remove()
   }
   function moveDown() {
-    var $this = $(this)
-    var rankCell = $this.closest('td')
-    var rank = rankCell.closest('tr')
+    var rankCell = $(this).closest('td')
+    var rank = rankCell.parent()
     var nextRank = rank.next()
     if (!nextRank.length) nextRank = $('<tr>').insertAfter(rank)
     nextRank.append(rankCell)
@@ -146,15 +144,18 @@
           break
         case QUESTION_TYPES['Elected position']:
           var response = []
-          var chosen = element.find('.chosen .list-group-item span.choice-text')
-          chosen.each(function() {
-            var $this = $(this)
-            var choiceId = $this.attr('choice-id'), userId = $this.attr('user-id')
-            response.push(
-              choiceId
-                ? {choice_id: Number(choiceId)}
-                : userId ? {user_id: Number(userId)} : null
-            )
+          element.find('.chosen tr').each(function() {
+            var rank = []
+            $(this).find('.choice-text').each(function() {
+              var $this = $(this)
+              var choiceId = $this.attr('choice-id'), userId = $this.attr('user-id')
+              rank.push(
+                choiceId
+                  ? {choice_id: Number(choiceId)}
+                  : userId ? {user_id: Number(userId)} : null
+              )
+            })
+            response.push(rank)
           })
           break
         case QUESTION_TYPES.Checkboxes:

--- a/donut/modules/voting/templates/take.html
+++ b/donut/modules/voting/templates/take.html
@@ -44,7 +44,7 @@
   function addChoice() {
     var $this = $(this)
     var element = $this.closest('.element')
-    var chosenList = element.find('.chosen')
+    var chosenTable = element.find('.chosen')
     var userId = $this.attr('user-id')
     if (userId) { //a writein
       var choice = $this.find('p').text()
@@ -62,10 +62,10 @@
     var displayedChoice = $('<span>').addClass('choice-text').text(choice)
     if (choiceId) displayedChoice.attr('choice-id', choiceId)
     else if (userId) displayedChoice.attr('user-id', userId)
-    chosenList.append(
-      $('<li>').addClass('list-group-item').append(
+    chosenTable.append(
+      $('<tr>').append($('<td>').append(
         displayedChoice,
-        $('<div>').addClass('btn-group space-right').append(
+        $('<div>').addClass('btn-group vote-controls').append(
           $('<button>').addClass('btn btn-default').click(removeChoice(userId)).append(
             $('<span>').addClass('glyphicon glyphicon-minus')
           ),
@@ -76,37 +76,43 @@
             $('<span>').addClass('glyphicon glyphicon-triangle-bottom')
           )
         )
-      )
+      ))
     )
   }
   function removeChoice(writein) {
     return function() {
       var $this = $(this)
-      var listGroupItem = $this.closest('.list-group-item')
+      var rankCell = $this.closest('td')
+      var rank = rankCell.closest('tr')
       if (!writein) {
-        var displayedChoice = listGroupItem.find('span')
+        var displayedChoice = rankCell.find('span')
         $this.closest('.element').find('.choices')
           .prepend(candidateInput({ //add back to choices list
             choice: displayedChoice.text(),
             id: displayedChoice.attr('choice-id')
           }))
       }
-      listGroupItem.remove()
+      rankCell.remove()
+      if (rank.is(':empty')) rank.remove()
     }
   }
   function moveUp() {
     var $this = $(this)
-    var listGroupItem = $this.closest('.list-group-item')
-    var previousItem = listGroupItem.prev()
-    if (!previousItem.length) return
-    listGroupItem.insertBefore(previousItem)
+    var rankCell = $this.closest('td')
+    var rank = rankCell.closest('tr')
+    var previousRank = rank.prev()
+    if (!previousRank.length) previousRank = $('<tr>').insertBefore(rank)
+    previousRank.append(rankCell)
+    if (rank.is(':empty')) rank.remove()
   }
   function moveDown() {
     var $this = $(this)
-    var listGroupItem = $this.closest('.list-group-item')
-    var nextItem = listGroupItem.next()
-    if (!nextItem.length) return
-    listGroupItem.insertAfter(nextItem)
+    var rankCell = $this.closest('td')
+    var rank = rankCell.closest('tr')
+    var nextRank = rank.next()
+    if (!nextRank.length) nextRank = $('<tr>').insertAfter(rank)
+    nextRank.append(rankCell)
+    if (rank.is(':empty')) rank.remove()
   }
   function electedPositionChoice(input) {
     return $('<div>').addClass('form-group').append(
@@ -242,7 +248,7 @@
               choicesDiv,
               $('<div>').addClass('col-md-6').append(
                 $('<h5>').text('Chosen:'),
-                $('<ul>').addClass('list-group chosen')
+                $('<table>').addClass('table chosen')
               )
             )
           )
@@ -279,6 +285,12 @@
     button[user-id] > p { /* override jumbotron p styles */
       font-size: 15px;
       margin-bottom: 0;
+    }
+    .vote-controls {
+      padding-left: 10px;
+    }
+    .vote-controls button {
+      padding: 0;
     }
   </style>
 {% endblock %}

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -148,12 +148,14 @@ INSERT INTO permissions(permission_id, permission_type, resource_name,
     (8, 'View', 'Bodfeedback summary', 'View a summary page of all bodfeedback'),
     (9, 'Edit', 'Bodfeedback', 'Mark a complaint read/unread'),
     (10, 'Edit', 'Bodfeedback emails', 'Add or remove subscribed emails from bodfeedback'),
-    (11, 'View', 'Bodfeedback emails', 'View the list of subscribed emails on bodfeedback');
+    (11, 'View', 'Bodfeedback emails', 'View the list of subscribed emails on bodfeedback'),
+    (33, 'Edit', 'Surveys', 'Create and manage surveys');
 
 INSERT INTO position_permissions(pos_id, permission_id) VALUES
     (1, 1),
     (5, 2),
-    (1, 3);
+    (1, 3),
+    (3, 33);
 
 
 INSERT INTO courses(

--- a/sql/voting.sql
+++ b/sql/voting.sql
@@ -18,6 +18,7 @@ CREATE TABLE surveys (
     creator        INT,                         -- user id of survey creator
 
     PRIMARY KEY(survey_id),
+    UNIQUE (access_key),
     FOREIGN KEY(group_id) REFERENCES groups(group_id) ON DELETE SET NULL,
     FOREIGN KEY(creator) REFERENCES members(user_id) ON DELETE SET NULL
 );

--- a/tests/modules/voting/test_voting.py
+++ b/tests/modules/voting/test_voting.py
@@ -15,23 +15,22 @@ from donut.modules.voting import helpers, routes, ranked_pairs
 # Ranked pairs
 def test_ranked_pairs():
     # Example taken from en.wikipedia.org/wiki/Ranked_pairs
-    MEMPHIS = 'Memphis'
-    NASHVILLE = 'Nashville'
-    CHATTANOOGA = 'Chattanooga'
-    KNOXVILLE = 'Knoxville'
-    responses = [[MEMPHIS, NASHVILLE, CHATTANOOGA, KNOXVILLE]] * 42
-    responses += [[NASHVILLE, CHATTANOOGA, KNOXVILLE, MEMPHIS]] * 26
-    responses += [[CHATTANOOGA, KNOXVILLE, NASHVILLE, MEMPHIS]] * 15
-    responses += [[KNOXVILLE, CHATTANOOGA, NASHVILLE, MEMPHIS]] * 17
-    correct_winners = [NASHVILLE, CHATTANOOGA, KNOXVILLE, MEMPHIS]
-    correct_winners = correct_winners[:ranked_pairs.WINNERS_TO_LIST]
-    assert ranked_pairs.winners(responses) == correct_winners
+    M = 'Memphis'
+    N = 'Nashville'
+    C = 'Chattanooga'
+    K = 'Knoxville'
+    responses = (((M, ), (N, ), (C, ), (K, )), ) * 42
+    responses += (((N, ), (C, ), (K, ), (M, )), ) * 26
+    responses += (((C, ), (K, ), (N, ), (M, )), ) * 15
+    responses += (((K, ), (C, ), (N, ), (M, )), ) * 17
+    assert ranked_pairs.winners(responses) == [N, C, K, M]
 
     # Test incomplete lists
-    assert ranked_pairs.winners([['A'], ['B'], ['A']]) == ['A', 'B']
+    assert ranked_pairs.winners([[['A']], [['B']], [['A']]]) == ['A', 'B']
 
-    # Test duplicate entries
-    assert ranked_pairs.winners([['A', 'B', 'A', 'A']]) == ['A', 'B']
+    # Test ties
+    responses = [[['A'], ['B', 'C'], ['D']], [['A', 'D', 'C'], ['B']]]
+    assert ranked_pairs.winners(responses) == ['A', 'C', 'B', 'D']
 
 
 # Helpers

--- a/tests/modules/voting/test_voting.py
+++ b/tests/modules/voting/test_voting.py
@@ -493,7 +493,7 @@ def test_respond(client):
             9: 'me'
         },
         'responses': [[[7], [-1], [9], [-2], [None]]],
-        'results': ['do', 'David Qu', 'me'],
+        'results': ['do', 'David Qu', 'me', 'Robert Eng', 'NO'],
         'responses': [[['do'], ['David Qu'], ['me'], ['Robert Eng'], ['NO']]]
     }]
     with app.test_request_context():


### PR DESCRIPTION
### Summary
- Candidates for elected position questions can now be ranked with multiple candidates per ranking. Ranked pairs will only tally candidates ranked in higher rankings against candidates ranked in lower rankings.
- Add validation that no candidates are ranked multiple times, since this could be used to inflate the ranked pairs tallies
- Added a surveys permission that is needed to create or edit surveys
- Fix a SQL bug when getting permissions for users who don't hold any positions
- Add an index on `surveys.access_key` for faster lookup

### Test Plan
- Tested new changes in the web interface
- Updated tests, still at 100% coverage