### PR TITLE
Fix warnings during tests

### DIFF
--- a/donut/testing/fixtures.py
+++ b/donut/testing/fixtures.py
@@ -11,6 +11,7 @@ def client():
     donut.init("test")
     # Need to specify a server, since test_client doesn't do that for us.
     app.config["SERVER_NAME"] = "127.0.0.1"
+    app.config["SESSION_COOKIE_DOMAIN"] = False  # suppress Flask warning
     app.config["JSONIFY_PRETTYPRINT_REGULAR"] = False
 
     # Establish an application context before running the tests.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-norecursedirs = env donut/modules/directory_search/utils donut/modules/courses/utils
+norecursedirs = .git donut/modules/courses/utils donut/modules/directory_search/utils donut/modules/editor/utils
 addopts = --cov donut --no-cov-on-fail
 ; add '--cov-report term-missing' to previous line for detailed coverage report

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 cov-core==1.15.0
-coverage==3.7.1
+coverage==5.0.3
 Flask==1.0.2
 flask_bootstrap==3.3.7.0
 itsdangerous==0.24
 MarkupSafe==0.23
-py==1.4.34
-pytest==3.2.2
-pytest-cov==1.8.1
+py==1.8.1
+pytest==5.3.5
+pytest-cov==2.8.1
 six==1.9.0
 PyMySQL==0.7.11
 yapf==0.18.0

--- a/tests/modules/voting/test_voting.py
+++ b/tests/modules/voting/test_voting.py
@@ -500,9 +500,9 @@ def test_respond(client):
         flask.session['username'] = 'dqu'
         # Invalid elected position response
         helpers.set_responses([5], ['[["abc"]]'])
-    with pytest.raises(
-            Exception, message='Unrecognized elected position vote'):
+    with pytest.raises(Exception) as e:
         helpers.get_results(1)
+    assert e.value.args == ('Unrecognized elected position vote', )
 
 
 def test_restrict_access(client):


### PR DESCRIPTION
### Summary
- Updated `pytest-cov` (and friends) to remove a warning message: `pytest_funcarg__cov: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.`
- Added `app.config["SESSION_COOKIE_DOMAIN"] = False` to remove the warning message: `UserWarning: The session cookie domain is an IP address. This may not work as intended in some browsers. Add an entry to your hosts file, for example "localhost.localdomain", and use that instead.`
- Make test collection faster by avoiding the `.git` directory and another directory with a recursive symlink