### PR TITLE
Positions fixed

### DIFF
--- a/donut/modules/core/helpers.py
+++ b/donut/modules/core/helpers.py
@@ -128,11 +128,11 @@ def get_group_list_of_member(user_id):
     Returns:
         result: All the groups that an user_id is a part of
     """
-    query = """SELECT DISTINCT group_id, group_name, control
-    FROM groups NATURAL JOIN positions p LEFT JOIN position_relations pr
-    ON p.pos_id=pr.pos_id_to INNER JOIN position_holders ph ON
-    ph.pos_id=p.pos_id OR pr.pos_id_from=ph.pos_id
-    WHERE user_id = %s"""
+    query = """
+        SELECT DISTINCT group_id, group_name, control
+        FROM groups NATURAL JOIN positions NATURAL JOIN current_position_holders
+        WHERE user_id = %s
+    """
 
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, [user_id])

--- a/donut/modules/directory_search/utils/import_registrar.py
+++ b/donut/modules/directory_search/utils/import_registrar.py
@@ -56,9 +56,7 @@ graduation_years = {
 
 get_options_query = "SELECT * FROM options"
 get_house_poss_query = """
-    SELECT group_name, pos_id
-    FROM group_houses NATURAL JOIN positions
-    WHERE pos_name = 'Full Member'
+    SELECT group_name, pos_id FROM house_positions WHERE pos_name = 'Full Member'
 """
 # The following values are updated on duplicate keys:
 # msc, preferred_name

--- a/donut/modules/directory_search/utils/import_registrar.py
+++ b/donut/modules/directory_search/utils/import_registrar.py
@@ -98,13 +98,16 @@ insert_option_query = """
     VALUES (%s, %s, 'Major')
 """
 get_house_membership_query = """
-    SELECT hold_id FROM position_holders WHERE user_id = %s AND pos_id = %s
+    SELECT hold_id FROM current_position_holders
+    WHERE user_id = %s AND pos_id = %s
 """
 add_house_membership_query = """
-    INSERT INTO position_holders (user_id, pos_id) VALUES (%s, %s)
+    INSERT INTO position_holders (user_id, pos_id, start_date)
+    VALUES (%s, %s, CURRENT_DATE)
 """
 end_house_membership_query = """
-    DELETE FROM position_holders WHERE user_id = %s AND pos_id IN
+    UPDATE position_holders SET end_date = CURRENT_DATE
+    WHERE user_id = %s AND pos_id IN
 """
 
 
@@ -195,7 +198,6 @@ def add_user_to_db(cursor, student, option_ids, house_pos_ids):
             cursor.execute(insert_option_query, (user_id, option_id))
 
     # Update house memberships
-    # TODO: use start and end dates to determine if position is active
     house = student["HOUSE_AFFILIATION_1"]  # 2 and 3 appear unpopulated
     if house and house != "Unaffiliated":
         pos_id = house_pos_ids.get(house)

--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -181,10 +181,7 @@ def get_position_data(fields=None, include_houses=True, order_by=None):
         NATURAL JOIN groups
     """
     if not include_houses:
-        query += """
-            WHERE pos_id NOT IN
-            (SELECT pos_id FROM group_house_membership)
-        """
+        query += ' WHERE pos_id NOT IN (SELECT pos_id FROM house_positions)'
     if order_by:
         if not all(field in fields for field in order_by):
             return "Invalid ORDER BY fields"

--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -90,7 +90,7 @@ def get_position_holders(pos_id):
 def get_positions_held(user_id):
     ''' Returns a list of all position id's held (directly or indirectly)
     by the given user. If no positions are found, [] is returned. '''
-    query = 'SELECT pos_id FROM current_position_holders WHERE user_id = %s'
+    query = 'SELECT DISTINCT pos_id FROM current_position_holders WHERE user_id = %s'
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, user_id)
         res = cursor.fetchall()
@@ -180,6 +180,7 @@ def get_position_data(fields=None, include_houses=True, order_by=None):
         NATURAL JOIN members_full_name
         NATURAL JOIN groups
     """
+
     if not include_houses:
         query += ' WHERE pos_id NOT IN (SELECT pos_id FROM house_positions)'
     if order_by:
@@ -300,11 +301,11 @@ def get_members_by_group(group_id):
         List where each element is a JSON representing the data of each
         person
     '''
-    query = "SELECT DISTINCT user_id FROM positions p LEFT JOIN "
-    query += "position_relations pr ON p.pos_id=pr.pos_id_to "
-    query += "INNER JOIN position_holders ph ON ph.pos_id=p.pos_id OR "
-    query += "pr.pos_id_from=ph.pos_id "
-    query += "WHERE group_id = %s"
+    query = """
+        SELECT DISTINCT user_id
+        FROM positions NATURAL JOIN current_position_holders
+        WHERE group_id = %s
+    """
 
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, [group_id])

--- a/donut/modules/groups/routes.py
+++ b/donut/modules/groups/routes.py
@@ -1,92 +1,148 @@
+from datetime import datetime
 import flask
-import json
 from flask import jsonify
 
+from donut.auth_utils import get_user_id
 from donut.modules.groups import blueprint, helpers
-from donut.validation_utils import validate_exists, validate_int, validate_date
+
+YYYY_MM_DD = "%Y-%m-%d"
 
 
-@blueprint.route("/1/groups/")
+@blueprint.route("/1/groups")
 def get_groups_list():
+    args = flask.request.args
     # Create a dict of the passed in attribute which are filterable
     filterable_attrs = ["group_id", "group_name", "group_desc", "type"]
     attrs = {
-        tup: flask.request.args[tup]
-        for tup in flask.request.args if tup in filterable_attrs
+        attr: value
+        for attr, value in args.items() if attr in filterable_attrs
     }
     fields = None
-    if "fields" in flask.request.args:
-        fields = [f.strip() for f in flask.request.args["fields"].split(',')]
+    if "fields" in args:
+        fields = [f.strip() for f in args["fields"].split(',')]
     return jsonify(helpers.get_group_list_data(fields=fields, attrs=attrs))
 
 
-@blueprint.route("/1/groups/<int:group_id>/positions/")
+@blueprint.route("/1/groups/<int:group_id>/positions")
 def get_group_positions(group_id):
-    """GET /1/groups/<int:group_id>/positions/"""
+    """GET /1/groups/<int:group_id>/positions"""
     return jsonify(helpers.get_group_positions(group_id))
 
 
-@blueprint.route("/1/positions/", methods=["POST", "GET"])
+@blueprint.route("/1/positions", methods=["GET"])
 def get_positions():
-    if flask.request.method == "GET":
-        return jsonify(helpers.get_position_data())
-    if flask.request.method == "POST":
-        form = flask.request.form
-        validations = [
-            validate_exists(form, "group_id")
-            and validate_int(form["group_id"]),
-            validate_exists(form, "pos_name"),
-        ]
-        if not all(validations):
-            return jsonify({'success': False})
-        else:
-            helpers.add_position(int(form["group_id"]), form["pos_name"])
-            return jsonify({'success': True})
+    return jsonify(helpers.get_position_data())
 
 
-@blueprint.route("/1/positions/delete/", methods=["POST"])
-def del_position():
+@blueprint.route("/1/positions", methods=["POST"])
+def create_position():
     form = flask.request.form
-    validations = [
-        validate_exists(form, "group_id") and validate_int(form["group_id"]),
-        validate_exists(form, "pos_id")
-    ]
-    if not all(validations):
-        return jsonify({'success': False})
-    helpers.delete_position(int(form["pos_id"]))
+    group_id = form.get('group_id')
+    try:
+        group_id = int(group_id)
+    except ValueError:
+        return jsonify({'success': False, 'message': 'Invalid group'})
+    pos_name = form.get('pos_name')
+    if not pos_name:
+        return jsonify({'success': False, 'message': 'Invalid position'})
+    username = flask.session.get('username')
+    if not (username and helpers.can_control(get_user_id(username), group_id)):
+        return jsonify({
+            'success': False,
+            'message': 'You do not control this group'
+        })
+
+    send = 'send' in form
+    control = 'control' in form
+    receive = 'receive' in form
+    try:
+        helpers.add_position(
+            group_id, pos_name, send=send, control=control, receive=receive)
+    except Exception as e:
+        flask.current_app.logger.error('Failed to create position:')
+        flask.current_app.logger.exception(e)
+        return jsonify({'success': False, 'message': 'Unable to add position'})
+
     return jsonify({'success': True})
 
 
-@blueprint.route("/1/groups/<int:group_id>/")
+@blueprint.route("/1/groups/<int:group_id>")
 def get_groups(group_id):
-    """GET /1/groups/<int:group_id>/"""
+    """GET /1/groups/<int:group_id>"""
     return jsonify(helpers.get_group_data(group_id))
 
 
-@blueprint.route("/1/groups/<int:group_id>/members/")
+@blueprint.route("/1/groups/<int:group_id>/members")
 def get_group_members(group_id):
-    """GET /1/groups/<int:group_id>/"""
+    """GET /1/groups/<int:group_id>"""
     return jsonify(helpers.get_members_by_group(group_id))
 
 
-@blueprint.route("/1/positions/<int:pos_id>/", methods=["GET"])
+@blueprint.route("/1/positions/<int:pos_id>", methods=["GET"])
 def get_pos_holders(pos_id):
-    """GET /1/positions/<int:pos_id>/"""
+    """GET /1/positions/<int:pos_id>"""
     return jsonify(helpers.get_position_holders(pos_id))
 
 
-@blueprint.route("/1/positions/<int:pos_id>/", methods=["POST"])
+@blueprint.route("/1/positions/<int:pos_id>", methods=["POST"])
 def create_pos_holder(pos_id):
     form = flask.request.form
-    validations = [
-        validate_exists(form, "user_id") and validate_int(form["user_id"]),
-        validate_exists(form, "start_date")
-        and validate_date(form["start_date"]),
-        validate_exists(form, "end_date") and validate_date(form["end_date"])
-    ]
-    if not all(validations):
-        return jsonify({'success': False})
-    helpers.create_position_holder(pos_id,
-                                   int(form["user_id"]), form["start_date"],
-                                   form["end_date"])
+    user_id = form.get('user_id')
+    try:
+        user_id = int(user_id)
+    except ValueError:
+        return jsonify({'success': False, 'message': 'Invalid user'})
+    start_date = form.get('start_date')
+    try:
+        start_date = datetime.strptime(start_date, YYYY_MM_DD)
+    except:
+        return jsonify({'success': False, 'message': 'Invalid start date'})
+    end_date = form.get('end_date')
+    try:
+        end_date = datetime.strptime(end_date, YYYY_MM_DD)
+    except:
+        return jsonify({'success': False, 'message': 'Invalid end date'})
+    if end_date < datetime.now() or end_date < start_date:
+        return jsonify({'success': False, 'message': 'End date is too early'})
+    username = flask.session.get('username')
+    group_id = helpers.get_position_group(pos_id)
+    if not (username and group_id
+            and helpers.can_control(get_user_id(username), group_id)):
+        return jsonify({
+            'success': False,
+            'message': 'You do not control this group'
+        })
+
+    try:
+        helpers.create_position_holder(pos_id, user_id, start_date, end_date)
+    except Exception as e:
+        flask.current_app.logger.error('Failed to add position holder:')
+        flask.current_app.logger.exception(e)
+        return jsonify({
+            'success': False,
+            'message': 'Unable to add position holder'
+        })
+    return jsonify({'success': True})
+
+
+@blueprint.route("/1/position_holds/<int:hold_id>", methods=("DELETE", ))
+def remove_pos_holder(hold_id):
+    username = flask.session.get('username')
+    group_id = helpers.get_hold_group(hold_id)
+    if not (username and group_id
+            and helpers.can_control(get_user_id(username), group_id)):
+        return jsonify({
+            'success': False,
+            'message': 'You do not control this group'
+        })
+
+    try:
+        helpers.end_position_holder(hold_id)
+    except Exception as e:
+        flask.current_app.logger.error('Failed to remove position holder:')
+        flask.current_app.logger.exception(e)
+        return jsonify({
+            'success': False,
+            'message': 'Unable to remove position holder'
+        })
     return jsonify({'success': True})

--- a/donut/modules/groups/routes.py
+++ b/donut/modules/groups/routes.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 import flask
 from flask import jsonify
 
@@ -102,7 +102,7 @@ def create_pos_holder(pos_id):
         end_date = datetime.strptime(end_date, YYYY_MM_DD)
     except:
         return jsonify({'success': False, 'message': 'Invalid end date'})
-    if end_date < datetime.now() or end_date < start_date:
+    if end_date.date() < date.today() or end_date < start_date:
         return jsonify({'success': False, 'message': 'End date is too early'})
     username = flask.session.get('username')
     group_id = helpers.get_position_group(pos_id)

--- a/donut/modules/newsgroups/helpers.py
+++ b/donut/modules/newsgroups/helpers.py
@@ -57,7 +57,7 @@ def get_user_actions(user_id, group_id):
     if not user_id:
         return None
     query = """
-        SELECT send, control, receive
+        SELECT send, control, receive AND subscribed AS receive
         FROM positions NATURAL JOIN current_position_holders
         WHERE user_id = %s AND group_id = %s
     """

--- a/donut/modules/newsgroups/helpers.py
+++ b/donut/modules/newsgroups/helpers.py
@@ -21,7 +21,7 @@ def get_newsgroups():
     """Gets all newsgroups."""
 
     query = '''
-    SELECT group_name, group_id FROM groups 
+    SELECT group_name, group_id FROM groups
     WHERE newsgroups=1
     '''
     with flask.g.pymysql_db.cursor() as cursor:
@@ -34,19 +34,18 @@ def get_my_newsgroups(user_id, send=False):
     If send is true, only gets newsgroups user can send to
     """
 
-    query = '''SELECT DISTINCT g.group_name, g.group_id
-    FROM positions p LEFT JOIN position_relations pr
-    ON p.pos_id=pr.pos_id_to
-    INNER JOIN position_holders ph ON ph.pos_id=p.pos_id OR
-    pr.pos_id_from=ph.pos_id
-    INNER JOIN groups g ON p.group_id=g.group_id
-    WHERE ph.user_id=%s AND g.newsgroups=1'''
+    query = """
+        SELECT DISTINCT group_id, group_name
+        FROM groups NATURAL JOIN positions NATURAL JOIN current_position_holders
+        WHERE newsgroups = 1 AND user_id = %s
+    """
     if send:
-        query += ''' AND p.send=1 
-        UNION DISTINCT SELECT group_name, group_id
-        FROM groups 
-        WHERE groups.newsgroups=1
-        AND groups.anyone_can_send=1'''
+        query += """
+            AND send = 1
+            UNION SELECT group_id, group_name
+            FROM groups
+            WHERE newsgroups = 1 AND anyone_can_send = 1
+        """
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, user_id)
         return cursor.fetchall()
@@ -58,13 +57,10 @@ def get_user_actions(user_id, group_id):
     if not user_id:
         return None
     query = """
-    SELECT p.send AS send, p.control AS control, p.receive AS receive
-    FROM positions p LEFT JOIN position_relations pr
-    ON p.pos_id=pr.pos_id_to
-    INNER JOIN position_holders ph ON ph.pos_id=p.pos_id OR
-    pr.pos_id_from=ph.pos_id
-    WHERE ph.user_id=%s AND p.group_id=%s"""
-    res = None
+        SELECT send, control, receive
+        FROM positions NATURAL JOIN current_position_holders
+        WHERE user_id = %s AND group_id = %s
+    """
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, (user_id, group_id))
         res = cursor.fetchall()
@@ -96,22 +92,20 @@ def unsubscribe(user_id, group_id):
     if not user_id:
         return None
     query = """
-    UPDATE position_holders 
-    SET receive = 0
-    WHERE user_id = %s AND pos_id IN (
-    SELECT p.pos_id FROM positions p LEFT JOIN position_relations pr
-    ON p.pos_id=pr.pos_id_to
-    INNER JOIN position_holders ph ON ph.pos_id=p.pos_id OR
-    pr.pos_id_from=ph.pos_id
-    WHERE ph.user_id=%s AND p.group_id=%s)
+        UPDATE position_holders
+        SET subscribed = 0
+        WHERE hold_id IN (
+            SELECT hold_id FROM current_position_holders NATURAL JOIN positions
+            WHERE user_id = %s AND group_id = %s
+        )
     """
     with flask.g.pymysql_db.cursor() as cursor:
-        cursor.execute(query, (user_id, user_id, group_id))
+        cursor.execute(query, (user_id, group_id))
 
 
 def get_applications(group_id):
     '''
-    Selects all applicants to a newgroups 
+    Selects all applicants to a newgroups
     '''
     query = """
     SELECT * FROM group_applications WHERE group_id = %s
@@ -128,10 +122,10 @@ def get_applications(group_id):
 
 def remove_application(user_id, group_id):
     '''
-    Admin has denied a person for their newgroup membership. 
+    Admin has denied a person for their newgroup membership.
     '''
     query = """
-    DELETE FROM group_applications 
+    DELETE FROM group_applications
     WHERE user_id = %s AND group_id = %s
     """
     with flask.g.pymysql_db.cursor() as cursor:
@@ -142,14 +136,10 @@ def send_email(data):
     """Sends email to newsgroup."""
 
     query = """
-   SELECT DISTINCT members.email
-   FROM positions p 
-   LEFT JOIN position_relations pr ON p.pos_id=pr.pos_id_to
-   INNER JOIN position_holders ph 
-   ON ph.pos_id=p.pos_id OR pr.pos_id_from=ph.pos_id
-   NATURAL JOIN members
-   WHERE group_id=%s AND p.receive=1 AND ph.receive=1
-   """
+        SELECT DISTINCT email
+        FROM positions NATURAL JOIN current_position_holders NATURAL JOIN members
+        WHERE group_id = %s AND receive = 1 AND subscribed = 1
+    """
     emails = None
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, data['group'])
@@ -168,7 +158,7 @@ def insert_email(user_id, data):
     """Insert email into db."""
 
     query = """
-    INSERT INTO newsgroup_posts 
+    INSERT INTO newsgroup_posts
     (group_id, subject, message, user_id, post_as)
     VALUES (%s, %s, %s, %s, %s)
     """
@@ -179,7 +169,7 @@ def insert_email(user_id, data):
 
 def get_post(post_id):
     query = """
-    SELECT group_name, group_id, subject, message, post_as, user_id, time_sent 
+    SELECT group_name, group_id, subject, message, post_as, user_id, time_sent
     FROM newsgroup_posts
     NATURAL JOIN groups
     WHERE newsgroup_post_id=%s
@@ -193,13 +183,9 @@ def get_owners(group_id):
     """Get users with control access to group."""
 
     query = """
-    SELECT ph.user_id, p.pos_name 
-    FROM positions p 
-    LEFT JOIN position_relations pr ON p.pos_id=pr.pos_id_to
-    INNER JOIN position_holders ph
-    ON ph.pos_id=p.pos_id OR pr.pos_id_from=ph.pos_id
-    WHERE p.control=1
-    AND p.group_id=%s
+        SELECT user_id, pos_name
+        FROM positions NATURAL JOIN current_position_holders
+        WHERE control = 1 AND group_id = %s
     """
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, group_id)
@@ -210,12 +196,9 @@ def get_posting_positions(group_id, user_id):
     """Get positions user can send as in a group."""
 
     query = """
-    SELECT p.pos_name, p.pos_id 
-    FROM positions p INNER JOIN position_holders ph 
-    ON p.pos_id=ph.pos_id
-    WHERE p.group_id=%s
-    AND ph.user_id=%s
-    AND p.send=1
+        SELECT pos_id, pos_name
+        FROM positions NATURAL JOIN current_position_holders
+        WHERE group_id = %s AND user_id = %s AND send = 1
     """
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, (group_id, user_id))

--- a/donut/modules/newsgroups/routes.py
+++ b/donut/modules/newsgroups/routes.py
@@ -99,7 +99,8 @@ def apply_subscription(group_id):
 def unsubscribe(group_id):
     if 'username' not in flask.session:
         return flask.abort(403)
-    helpers.unsubscribe(flask.session['username'], group_id)
+    helpers.unsubscribe(
+        auth_utils.get_user_id(flask.session['username']), group_id)
     flask.flash('Successfully unsubscribed')
     return flask.redirect(
         flask.url_for('newsgroups.view_group', group_id=group_id))

--- a/donut/modules/newsgroups/templates/group.html
+++ b/donut/modules/newsgroups/templates/group.html
@@ -5,7 +5,9 @@
   <h1> Must be a member to view </h1>
 {% else %}
   <h1> {{ group['group_name'] }} </h1>
-  <h2> {{ group['group_desc'] }} </h2>
+  {% if group['group_desc'] %}
+    <h2> {{ group['group_desc'] }} </h2>
+  {% endif %}
   {% if not member %}
     <form method="POST" id="apply" action="{{ url_for('newsgroups.apply_subscription', group_id=group['group_id']) }}">
       <div class="form-group">
@@ -25,10 +27,10 @@
   {% endif %}
   {% if actions["receive"] %}
     <h4> You are subscribed. </h4>
-  {% else %} 
+  {% else %}
     <h4> You are not subscribed. </h4>
   {% endif %}
-  {% if actions["control"] %} 
+  {% if actions["control"] %}
     <h4> You have admin control. </h4>
     <h4> Applications </h4>
     <table style="width:100%">

--- a/donut/routes.py
+++ b/donut/routes.py
@@ -25,18 +25,15 @@ def campus_positions():
     also collect the total list of positions and pass it in'''
     approved_group_ids = []
     approved_group_names = []
-    if 'username' in flask.session:
-        user_id = get_user_id(flask.session['username'])
-        result = helpers.get_group_list_of_member(user_id)
-        for res in result:
-            if res["control"] == 1:
-                approved_group_ids.append(res["group_id"])
-                approved_group_names.append(res["group_name"])
-    all_positions = groups.helpers.get_position_data()
-    for pos in all_positions:
-        # Format the date information nicely
-        pos['start_date'] = str(pos['start_date'])
-        pos['end_date'] = str(pos['end_date'])
+    username = flask.session.get('username')
+    if username:
+        user_id = get_user_id(username)
+        for group in helpers.get_group_list_of_member(user_id):
+            if group["control"]:
+                approved_group_ids.append(group["group_id"])
+                approved_group_names.append(group["group_name"])
+    all_positions = groups.helpers.get_position_data(
+        include_houses=False, order_by=("group_name", "pos_name"))
     return flask.render_template(
         'campus_positions.html',
         approved_group_ids=approved_group_ids,

--- a/donut/static/js/groups/positions.js
+++ b/donut/static/js/groups/positions.js
@@ -22,12 +22,10 @@ function init(approvedGroupIds, approvedGroupNames, allPos) {
  */
 function populateAdminGroups(approvedGroupIds, approvedGroupNames) {
     for (var i = 0; i < approvedGroupIds.length; i++) {
-        var newOption = $('<option>')
+        $('#groupCreate').append($('<option>')
             .attr('value', approvedGroupIds[i])
-            .text(approvedGroupNames[i]);
-        $('#groupCreate').append(newOption);
-        $('#groupDel').append(newOption.clone());
-        $('#groupPosHold').append(newOption.clone());
+            .text(approvedGroupNames[i])
+        );
     }
 }
 
@@ -98,7 +96,7 @@ function filterChange() {
     var posIndex = parseInt($('#positionSelect').val());
     $('#positionsTable tbody tr').remove();
     allPositions.forEach(function(position) {
-        // If a position is being filtered, ignore the group filter
+        // If filtering by position, ignore the group filter
         if (posIndex
             ? posIndex == position.pos_id
             : (!groupIndex || groupIndex === position.group_id)

--- a/donut/templates/campus_positions.html
+++ b/donut/templates/campus_positions.html
@@ -1,9 +1,5 @@
 {% extends "layout.html" %}
 {% block page %}
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-<script src="{{ url_for('static', filename='js/groups/positions.js') }}"></script>
-
-
 <div class="container theme-showcase" role="main">
   <div class="jumbotron">
     <div id="page-header">
@@ -11,7 +7,9 @@
     </div>
     <ul class="nav nav-tabs nav-justified tabs">
         <li class="active"><a data-toggle="tab" href="#viewAll">View All</a></li>
-        <li><a data-toggle="tab" href="#admin">Administrate</a></li>
+        {% if approved_group_ids %}
+            <li><a data-toggle="tab" href="#admin">Administrate</a></li>
+        {% endif %}
     </ul>
     <div class="jumbotron">
     <div class="tab-content">
@@ -24,12 +22,12 @@
                     <option value="0">All Positions</option>
                 </select>
             </div>
-            <table id="positionsTable">
+            <table class="table" id="positionsTable">
                 <thead>
                     <tr>
-                        <td width=25%><strong>Group</strong></td>
-                        <td width=20%><strong>Position</strong></td>
-                        <td width=25%><strong>Student</strong></td>
+                        <th>Group</th>
+                        <th>Position</th>
+                        <th>Student</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -42,109 +40,112 @@
                     <a data-toggle="pill" class="btn btn-primary" href="#createPos">Create a Position</a>
                 </li>
                 <li>
-                    <a data-toggle="pill" class="btn btn-primary" href="#deletePos">Delete a Position</a>
+                    <a data-toggle="pill" class="btn btn-primary" href="#assignHold">Add a Position Holder</a>
                 </li>
                 <li>
-                    <a data-toggle="pill" href="#assignHold">Assign a Position Holder</a>
+                    <a data-toggle="pill" class="btn btn-primary" href="#removeHold">Remove a Position Holder</a>
                 </li>
             </ul>
             <div class="tab-content">
                 <div id="createPos" class="tab-pane fade in active">
                     <form id="posCreate">
                         <div class="form-group">
-                            <label class="control-label col-sm-2" for="groupCreate">
-                                Group Name:</label>
-                            <select class="form-control" id="groupCreate" 
-                                                            name="group_id"> 
-                                <option> Select a Group </option>
+                            <label class="required" for="groupCreate">Group Name:</label>
+                            <select class="form-control" id="groupCreate" name="group_id">
+                                <option>Pick a Group</option>
                             </select>
                         </div>
                         <div class="form-group">
-                            <label class="control-label col-sm-2" for="posName">
-                                Position Name: </label>
-                            <input class="form-control" id="posName" 
-                                                            name="pos_name">
+                            <label class="required" for="posName">Position Name:</label>
+                            <input class="form-control" id="posName" name="pos_name" />
                         </div>
+                        <div class="form-group">
+                            <label>
+                                <input type="checkbox" name="receive" checked />
+                                Receives emails from the group
+                            </label>
+                        </div>
+                        <div class="form-group">
+                            <label>
+                                <input type="checkbox" name="send" />
+                                Can send emails to the group
+                            </label>
+                        </div>
+                        <div class="form-group">
+                            <label>
+                                <input type="checkbox" name="control" />
+                                Can manage the group
+                            </label>
+                        </div>
+                        <button type="button" class="btn btn-default" onclick="submitPosForm()">
+                            Add Position
+                        </button>
                     </form>
-                </div>
-                <div id="deletePos" class="tab-pane fade in">
-                    <form id="posDelete">
-                        <div class="form-group">
-                            <label class="control-label col-sm-2" for="groupDel">
-                                Group Name:</label>
-                            <select class="form-control" id="groupDel" 
-                                    onchange="groupDelChange()" name="group_id">
-                                <option> Select a Group </option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-sm-2" for="position">
-                                Position: </label>
-                            <select class="form-control" id="position" name="pos_id">
-                                <option> Pick a position </option>
-                            </select>
-                        </div>
-                    </form>     
                 </div>
                 <div id="assignHold" class="tab-pane fade in">
                     <form id="holdForm">
                         <div class="form-group">
-                            <label class="control-label col-sm-2" for="groupPosHold">
-                                Group Name:</label>
-                            <select class="form-control" id="groupPosHold" 
-                                    onchange="groupPosHoldChange()" name="group_id"> 
-                                <option> Select a Group </option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label col-sm-2" for="posIdHold">
-                                Position: </label>
-                            <select class="form-control" id="posIdHold" 
-                                                            name="pos_id">
-                                <option> Pick a position </option>
+                            <label class="required" for="posIdHold">Position:</label>
+                            <select class="form-control" id="posIdHold">
+                                <option>Pick a Position</option>
                             </select>
                         </div>
                         <div class='form-group'>
-                            <label class="control-label col-sm-2" for='name'>
-                                Name: </label>
-                            <input class='form-control' id='name' name='name' 
-                                autocomplete="off" placeholder='Name' autofocus />
+                            <label class="required" for='name'>Name:</label>
+                            <input class='form-control' id='name'
+                                autocomplete="off" placeholder='Search by name' />
                             <ul class='list-group' id='name-search'></ul>
                         </div>
-                        <input type="hidden" id="user_id" name="user_id">
+                        <input type="hidden" id="user_id" name="user_id" />
                         <div class='form-group'>
-                            <label for='start_date'> Start Date: </label>
+                            <label class='required' for='start_date'>Start Date:</label>
                             <input id='start_date' type='date' name='start_date'/>
                         </div>
                         <div class='form-group'>
-                            <label for='end_date'> End Date: </label>
+                            <label class='required' for='end_date'>End Date:</label>
                             <input id='end_date' type='date' name='end_date'/>
                         </div>
-                        <button id="submitPosHoldBtn" class="btn btn-default">
-                            Submit
+                        <button type="button" class="btn btn-default" onclick="submitHoldForm()">
+                            Add Position Holder
                         </button>
                     </form>
                 </div>
-            </div> 
+                <div id="removeHold" class="tab-pane fade in">
+                    <form id="removeHoldForm">
+                        <div class="form-group">
+                            <label class="required" for="posHold">Position Holder:</label>
+                            <select class="form-control" id="posHold">
+                                <option>Pick a Position Holder</option>
+                            </select>
+                        </div>
+                        <button type="button" class="btn btn-default" onclick="submitRemoveHoldForm()">
+                            End Position Holder's Term
+                        </button>
+                    </form>
+                </div>
+            </div>
         </div>
     </div>
   </div>
 </div>
-<script type="text/javascript">
-init({{approved_group_ids}},{{approved_group_names|safe}},
-    {{all_positions|safe}});
-</script>
 {% endblock %}
 {% block scripts %}
     {{ super() }}
+    <script src="{{ url_for('static', filename='js/groups/positions.js') }}"></script>
     <script src='{{ url_for("static", filename="js/search-directory.js") }}'></script>
     <script>
+        init(
+            {{ approved_group_ids|tojson|safe }},
+            {{ approved_group_names|tojson|safe }},
+            {{ all_positions|tojson|safe }}
+        );
+
         $(document).ready(function() {
             var nameInput = $('input#name'), nameSearch = $('ul#name-search')
-            attachDirectorySearch(nameInput, nameSearch, function(user){
+            attachDirectorySearch(nameInput, nameSearch, function(user) {
                 return $('<li>').addClass('list-group-item').append($('<a>')
-                        .text(user.full_name + ", " + user.graduation_year)
-                        .click(function(){
+                        .text(user.full_name)
+                        .click(function() {
                                 nameInput.val(user.full_name);
                                 nameSearch.children().remove();
                                 $('input#user_id').val(user.user_id);

--- a/sql/donut.sql
+++ b/sql/donut.sql
@@ -221,15 +221,14 @@ CREATE VIEW current_position_holders AS (
     SELECT * FROM current_direct_position_holders
     UNION ALL
     SELECT
-        holders.hold_id,
-        relations.pos_id_to AS pos_id,
-        holders.user_id,
-        holders.start_date,
-        holders.end_date,
-        holders.subscribed
-    FROM current_direct_position_holders holders
-        JOIN position_relations relations
-        ON holders.pos_id = relations.pos_id_from
+        current_direct_position_holders.hold_id,
+        position_relations.pos_id_to AS pos_id,
+        current_direct_position_holders.user_id,
+        current_direct_position_holders.start_date,
+        current_direct_position_holders.end_date,
+        current_direct_position_holders.subscribed
+    FROM current_direct_position_holders
+        JOIN position_relations ON pos_id = pos_id_from
 );
 
 -- News items to show on the homepage

--- a/sql/donut.sql
+++ b/sql/donut.sql
@@ -177,7 +177,7 @@ CREATE TABLE position_holders (
     user_id    INT  NOT NULL,
     start_date DATE DEFAULT NULL,
     end_date   DATE DEFAULT NULL,
-    receive    BOOLEAN DEFAULT TRUE, -- Toggles whether user is subscribed to newsgroup
+    subscribed BOOLEAN DEFAULT TRUE, -- Toggles whether user is subscribed to newsgroup
     PRIMARY KEY (hold_id),
     FOREIGN KEY (pos_id)
         REFERENCES positions(pos_id)
@@ -226,7 +226,7 @@ CREATE VIEW current_position_holders AS (
         holders.user_id,
         holders.start_date,
         holders.end_date,
-        holders.receive
+        holders.subscribed
     FROM current_direct_position_holders holders
         JOIN position_relations relations
         ON holders.pos_id = relations.pos_id_from

--- a/sql/donut.sql
+++ b/sql/donut.sql
@@ -2,6 +2,8 @@
 -- TODO: Better comments
 
 DROP TABLE IF EXISTS news;
+DROP VIEW IF EXISTS current_position_holders;
+DROP VIEW IF EXISTS current_direct_position_holders;
 DROP TABLE IF EXISTS position_relations;
 DROP VIEW IF EXISTS group_house_membership;
 DROP VIEW IF EXISTS group_houses;
@@ -139,12 +141,12 @@ CREATE TABLE groups (
 CREATE TABLE newsgroup_posts (
     newsgroup_post_id       INT          NOT NULL AUTO_INCREMENT,
     group_id                INT          NOT NULL, -- Which group was it to
-    subject                 TEXT         NOT NULL, 
+    subject                 TEXT         NOT NULL,
     message                 TEXT         NOT NULL,
     post_as		    VARCHAR(32)  DEFAULT NULL,
     user_id                 INT          NOT NULL, -- Who sent this message
     time_sent               TIMESTAMP    DEFAULT CURRENT_TIMESTAMP, -- When were messages sent
-    PRIMARY KEY (newsgroup_post_id), 
+    PRIMARY KEY (newsgroup_post_id),
     FOREIGN KEY (group_id) REFERENCES groups(group_id),
     FOREIGN KEY (user_id) REFERENCES members(user_id)
 );
@@ -164,7 +166,8 @@ CREATE TABLE positions (
     PRIMARY KEY (pos_id),
     FOREIGN KEY (group_id)
         REFERENCES groups(group_id)
-        ON DELETE CASCADE
+        ON DELETE CASCADE,
+    UNIQUE (group_id, pos_name)
 );
 
 -- Position to Member Table
@@ -208,6 +211,29 @@ CREATE TABLE position_relations (
     FOREIGN KEY (pos_id_to) REFERENCES positions(pos_id)
 );
 
+-- Filters the position_holders table to only list holds that are active
+CREATE VIEW current_direct_position_holders AS (
+    SELECT * FROM position_holders
+    WHERE (start_date IS NULL OR start_date <= CURRENT_DATE)
+        AND (end_date IS NULL OR CURRENT_DATE <= end_date)
+);
+-- All direct and indirect position holds that are currently active.
+-- This should be used in general for querying held positions.
+CREATE VIEW current_position_holders AS (
+    SELECT * FROM current_direct_position_holders
+    UNION ALL
+    SELECT
+        holders.hold_id,
+        relations.pos_id_to AS pos_id,
+        holders.user_id,
+        holders.start_date,
+        holders.end_date,
+        holders.receive
+    FROM current_direct_position_holders holders
+        JOIN position_relations relations
+        ON holders.pos_id = relations.pos_id_from
+);
+
 -- News items to show on the homepage
 CREATE TABLE news (
     news_id     INT  NOT NULL AUTO_INCREMENT,
@@ -216,9 +242,9 @@ CREATE TABLE news (
     PRIMARY KEY (news_id)
 );
 CREATE TABLE group_applications (
-    user_id         INT NOT NULL, 
-    group_id        INT NOT NULL, 
+    user_id         INT NOT NULL,
+    group_id        INT NOT NULL,
     PRIMARY KEY (user_id, group_id),
     FOREIGN KEY (user_id) REFERENCES members(user_id),
     FOREIGN KEY (group_id) REFERENCES groups(group_id)
-)
+);

--- a/sql/donut.sql
+++ b/sql/donut.sql
@@ -5,8 +5,8 @@ DROP TABLE IF EXISTS news;
 DROP VIEW IF EXISTS current_position_holders;
 DROP VIEW IF EXISTS current_direct_position_holders;
 DROP TABLE IF EXISTS position_relations;
-DROP VIEW IF EXISTS group_house_membership;
-DROP VIEW IF EXISTS group_houses;
+DROP VIEW IF EXISTS house_positions;
+DROP VIEW IF EXISTS house_groups;
 DROP TABLE IF EXISTS position_holders;
 DROP TABLE IF EXISTS positions;
 DROP TABLE IF EXISTS groups;
@@ -185,21 +185,19 @@ CREATE TABLE position_holders (
     FOREIGN KEY (user_id) REFERENCES members(user_id)
 );
 
--- House View
+-- Houses View
 -- Because houses are used so much, make a view separate from the groups
 -- table.
-CREATE VIEW group_houses AS (
+CREATE VIEW house_groups AS (
     SELECT group_id, group_name FROM groups WHERE type = 'house'
 );
-
--- House Members View
--- Because house membership is used so much, make a view separate from the
--- positions table.
-CREATE VIEW group_house_membership AS (
-    SELECT user_id, group_id, pos_id
-    FROM group_houses NATURAL JOIN positions NATURAL JOIN position_holders
-    WHERE UPPER(pos_name) = UPPER('Full Member')
-        OR UPPER(pos_name) = UPPER('Social Member')
+-- House Positions View
+-- House membership positions are special,
+-- so make a view separate from the positions table.
+CREATE VIEW house_positions AS (
+    SELECT group_id, group_name, pos_id, pos_name
+    FROM house_groups NATURAL JOIN positions
+    WHERE pos_name IN ('Full Member', 'Social Member')
 );
 
 -- Position to position table

--- a/sql/permissions.sql
+++ b/sql/permissions.sql
@@ -13,8 +13,9 @@ CREATE TABLE permissions (
 CREATE TABLE position_permissions (
        pos_id INT NOT NULL,
        permission_id INT NOT NULL,
-       FOREIGN KEY(pos_id) REFERENCES positions(pos_id) 
+       PRIMARY KEY(pos_id, permission_id),
+       FOREIGN KEY(pos_id) REFERENCES positions(pos_id)
        ON UPDATE CASCADE ON DELETE CASCADE,
        FOREIGN KEY(permission_id) REFERENCES permissions(permission_id)
        ON UPDATE CASCADE ON DELETE CASCADE
-); 
+);

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -114,21 +114,6 @@ def test_get_position_data(client):
     assert len(res) == 8
 
 
-def test_delete_position(client):
-    assert helpers.get_group_positions(1) == [{
-        "pos_id": 1,
-        "pos_name": "Head"
-    }, {
-        "pos_id": 2,
-        "pos_name": "Secretary"
-    }]
-    helpers.delete_position(1)
-    assert helpers.get_group_positions(1) == [{
-        "pos_id": 2,
-        "pos_name": "Secretary"
-    }]
-
-
 def test_get_group_data(client):
     assert helpers.get_group_data(4) == {}
     assert helpers.get_group_data(1, ["not_a_real_field"]) == "Invalid field"

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -53,32 +53,102 @@ def test_get_group_positions_data(client):
 
 def test_get_position_holders(client):
     res = helpers.get_position_holders(5)
-    assert len(res) == 3
-    assert set(row['first_name']
-               for row in res) == set(['Robert', 'Sean', 'Rachel'])
+    res = sorted(
+        res, key=lambda holder: (holder['user_id'], holder['hold_id']))
+    assert res == [{
+        'user_id': 2,
+        'full_name': 'Robert Eng',
+        'hold_id': 5,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 4,
+        'full_name': 'Sean Yu',
+        'hold_id': 4,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 4,
+        'full_name': 'Sean Yu',
+        'hold_id': 6,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 5,
+        'full_name': 'Rachel Lin',
+        'hold_id': 7,
+        'start_date': None,
+        'end_date': None
+    }]
 
     res = helpers.get_position_holders(1)
-    assert len(res) == 2
-    assert set(row['first_name'] for row in res) == set(['Robert', 'David'])
+    res = sorted(
+        res, key=lambda holder: (holder['user_id'], holder['hold_id']))
+    assert res == [{
+        'user_id': 1,
+        'full_name': 'David Qu',
+        'hold_id': 1,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 2,
+        'full_name': 'Robert Eng',
+        'hold_id': 2,
+        'start_date': None,
+        'end_date': None
+    }]
 
     res = helpers.get_position_holders([1, 5])
-    assert len(res) == 4
-    assert set(row['first_name']
-               for row in res) == set(['Robert', 'Sean', 'David', 'Rachel'])
+    res = sorted(
+        res, key=lambda holder: (holder['user_id'], holder['hold_id']))
+    assert res == [{
+        'user_id': 1,
+        'full_name': 'David Qu',
+        'hold_id': 1,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 2,
+        'full_name': 'Robert Eng',
+        'hold_id': 2,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 2,
+        'full_name': 'Robert Eng',
+        'hold_id': 5,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 4,
+        'full_name': 'Sean Yu',
+        'hold_id': 4,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 4,
+        'full_name': 'Sean Yu',
+        'hold_id': 6,
+        'start_date': None,
+        'end_date': None
+    }, {
+        'user_id': 5,
+        'full_name': 'Rachel Lin',
+        'hold_id': 7,
+        'start_date': None,
+        'end_date': None
+    }]
 
 
 def test_get_positions_held(client):
     res = helpers.get_positions_held(4)
-    assert len(res) == 2
-    assert 4 in res and 5 in res
+    assert sorted(res) == [4, 5]
 
     res = helpers.get_positions_held(2)
-    assert len(res) == 3
-    assert 1 in res and 4 in res and 5 in res
+    assert sorted(res) == [1, 4, 5]
 
     res = helpers.get_positions_held(1)
-    assert len(res) == 1
-    assert 1 in res
+    assert res == [1]
 
     res = helpers.get_positions_held(-1)
     assert res == []
@@ -93,23 +163,21 @@ def test_get_position_id(client):
 
 def test_get_position_data(client):
     res = helpers.get_position_data()
-    assert res[0]["first_name"] == "David"
-    assert res[0]["last_name"] == "Qu"
-    assert res[0]["group_name"] == "Donut Devteam"
-    assert res[0]["user_id"] == 1
-    assert res[0]["pos_name"] == "Head"
-    assert res[0]["group_id"] == 1
-    assert res[0]["pos_id"] == 1
     assert {
-        "first_name": "Robert",
-        "last_name": "Eng",
-        "group_name": "IHC",
+        "user_id": 1,
+        "full_name": "David Qu",
+        "group_id": 1,
+        "group_name": "Donut Devteam",
+        "pos_id": 1,
+        "pos_name": "Head"
+    } in res
+    assert {
         "user_id": 2,
-        "pos_name": "Member",
+        "full_name": "Robert Eng",
         "group_id": 3,
+        "group_name": "IHC",
         "pos_id": 5,
-        "start_date": None,
-        "end_date": None
+        "pos_name": "Member"
     } in res
     assert len(res) == 8
 
@@ -124,24 +192,21 @@ def test_get_group_data(client):
 
 
 def test_create_pos_holders(client):
-    helpers.create_position_holder(3, 3, "2018-02-22", "2019-02-22")
-    assert helpers.get_position_holders(3) == [{
-        "user_id": 3,
-        "first_name": "Caleb",
-        "last_name": "Sander",
-        "start_date": None,
-        "end_date": None
+    helpers.create_position_holder(3, 3, "2018-02-22", "3005-01-01")
+    res = helpers.get_position_holders(3)
+    res = sorted(res, key=lambda holder: holder['hold_id'])
+    assert res == [{
+        'user_id': 3,
+        'full_name': 'Belac Sander',
+        'hold_id': 3,
+        'start_date': None,
+        'end_date': None
     }, {
-        "user_id":
-        3,
-        "first_name":
-        "Caleb",
-        "last_name":
-        "Sander",
-        "start_date":
-        datetime.date(2018, 2, 22),
-        "end_date":
-        datetime.date(2019, 2, 22)
+        'user_id': 3,
+        'full_name': 'Belac Sander',
+        'hold_id': 8,
+        'start_date': datetime.date(2018, 2, 22),
+        'end_date': datetime.date(3005, 1, 1)
     }]
 
 

--- a/tests/modules/newsgroups/test_newsgroups.py
+++ b/tests/modules/newsgroups/test_newsgroups.py
@@ -93,10 +93,12 @@ def test_subscriptions(client):
 
 
 def test_get_owners(client):
-    assert helpers.get_owners(2) == [{
-        'user_id': 4,
+    res = helpers.get_owners(2)
+    res = sorted(res, key=lambda owner: owner['user_id'])
+    assert res == [{
+        'user_id': 2,
         'pos_name': 'President'
     }, {
-        'user_id': 2,
+        'user_id': 4,
         'pos_name': 'President'
     }]


### PR DESCRIPTION
### Summary
- Fixed position administration actions:
  - Administration forms actually have submit buttons now lol
  - Administration routes actually check that the user has control permissions
  - Add a form for ending the term of a current position holder
  - Removed the "delete position" form since I think we want to keep historical information about positions
  - Can now specify send/control/receive privileges when creating new positions
  - Show all positions in groups that the user controls instead of having to select the group to control first
  - Give more useful error messages
- Fix XSS vulnerabilities in positions page due to building HTML strings with unescaped positions data (yikes)
- UI improvements to campus positions page: show the group that positions belong to in the dropdown, order holders by group name and position name, use a Bootstrap table, exclude house memberships from query so page loads faster
- Made a `current_position_holders` view that checks position start and end dates, and also includes indirect positions. This should be the go-to for position queries. I have switched out all the `position_holders` queries with this view so the logic is consistent.
- Renamed `position_holders.receive` to `position_holders.subscribed` so that `NATURAL JOIN`s with `positions` behave as expected
- Add a `house_positions` view to make selecting for/excluding house membership positions easier. Removed the `group_house_membership` view since it can easily be emulated with `house_positions NATURAL JOIN current_position_holders`.
- Renamed `group_houses` to `house_groups` because I could never remember the table name. Sorry, Rachel :(
- Fix newsgroups unsubscribe route, though I don't think this is actually accessible?

### Test Plan
- Tests passing
- Thoroughly tested all the position administration actions and the SQL queries that changed