### PR TITLE
Add administrators to ug-* groups

### DIFF
--- a/donut/modules/directory_search/utils/update_ug_groups.py
+++ b/donut/modules/directory_search/utils/update_ug_groups.py
@@ -22,11 +22,12 @@ def update_ug_groups(env):
             ug_group = get_ug_group(cursor)
             ug_type = ug_group['type']
             ug_pos_id = ug_group['pos_id']
+            ug_admin_positions = get_ug_admin_positions(cursor)
 
             remove_ug_group_members(cursor, ug_pos_id)
             remove_ug_year_groups(cursor)
             add_ug_group_members(cursor, ug_pos_id)
-            pos_ids = make_ug_year_groups(cursor, ug_type)
+            pos_ids = make_ug_year_groups(cursor, ug_type, ug_admin_positions)
             add_ug_year_members(cursor, pos_ids)
         db.commit()
     finally:
@@ -37,7 +38,7 @@ def get_ug_group(cursor):
     query = """
         SELECT type, pos_id
         FROM groups NATURAL JOIN positions
-        WHERE group_name = 'ug'
+        WHERE group_name = 'ug' AND pos_name = 'Member'
     """
     cursor.execute(query)
     ug_group = cursor.fetchone()
@@ -45,6 +46,16 @@ def get_ug_group(cursor):
         raise Exception('"ug" group/position not found')
 
     return ug_group
+
+
+def get_ug_admin_positions(cursor):
+    query = """
+        SELECT pos_id_from
+        FROM position_relations JOIN positions ON pos_id_to = pos_id NATURAL JOIN groups
+        WHERE group_name = 'ug' AND pos_name = 'Admin'
+    """
+    cursor.execute(query)
+    return [relation['pos_id_from'] for relation in cursor.fetchall()]
 
 
 def remove_ug_group_members(cursor, ug_pos_id):
@@ -64,7 +75,7 @@ def add_ug_group_members(cursor, ug_pos_id):
     print('Added', members, 'undergrads to ug')
 
 
-def make_ug_year_groups(cursor, group_type):
+def make_ug_year_groups(cursor, group_type, ug_admin_positions):
     get_years_query = """
         SELECT DISTINCT graduation_year
         FROM members WHERE graduation_year >= %s
@@ -76,6 +87,13 @@ def make_ug_year_groups(cursor, group_type):
     make_position_query = """
         INSERT INTO positions(group_id, pos_name)
         VALUES (%s, 'Member')
+    """
+    make_admin_position_query = """
+        INSERT INTO positions(group_id, pos_name, send, control)
+        VALUES (%s, 'Admin', TRUE, TRUE)
+    """
+    add_admin_relation_query = """
+        INSERT INTO position_relations(pos_id_from, pos_id_to) VALUES (%s, %s)
     """
 
     pos_ids = {}
@@ -89,6 +107,10 @@ def make_ug_year_groups(cursor, group_type):
         group_id = cursor.lastrowid
         cursor.execute(make_position_query, group_id)
         pos_ids[year] = cursor.lastrowid
+        cursor.execute(make_admin_position_query, group_id)
+        admin_pos_id = cursor.lastrowid
+        for pos_id in ug_admin_positions:
+            cursor.execute(add_admin_relation_query, (pos_id, admin_pos_id))
         print('Created group', group_name)
     return pos_ids
 

--- a/sql/donut.sql
+++ b/sql/donut.sql
@@ -193,8 +193,8 @@ CREATE TABLE position_relations (
     pos_id_from   INT  NOT NULL,
     pos_id_to     INT  NOT NULL,
     PRIMARY KEY (pos_id_from, pos_id_to),
-    FOREIGN KEY (pos_id_from) REFERENCES positions(pos_id),
-    FOREIGN KEY (pos_id_to) REFERENCES positions(pos_id)
+    FOREIGN KEY (pos_id_from) REFERENCES positions(pos_id) ON DELETE CASCADE,
+    FOREIGN KEY (pos_id_to) REFERENCES positions(pos_id) ON DELETE CASCADE
 );
 
 -- Filters the position_holders table to only list holds that are active


### PR DESCRIPTION
### Summary
Copies the `position_relations` giving positions (e.g. BoD, IHC, RevComm, Devteam) control/send permissions for the `ug` group to the `ug-YEAR` groups. Updated the Wiki with the SQL for initializing these position relations. Also added `CASCADE`s to the `position_relations` table so positions can be removed without removing all their relations.

### Test Plan
- Ran script, verified `ug` admins get added as admins for the new `ug-*` groups
