### PR TITLE
newsgroup fixes

### DIFF
--- a/donut/email_utils.py
+++ b/donut/email_utils.py
@@ -2,7 +2,7 @@ import smtplib
 from email.mime.text import MIMEText
 
 
-def send_email(poster, to, text, subject, use_prefix=True, group=None):
+def send_email(to, text, subject, use_prefix=True, group=None, poster=''):
     """
     Sends an email to a user. Expects 'to' to be a comma separated string of
     emails, and for 'msg' and 'subject' to be strings. If group

--- a/donut/email_utils.py
+++ b/donut/email_utils.py
@@ -2,7 +2,7 @@ import smtplib
 from email.mime.text import MIMEText
 
 
-def send_email(to, text, subject, use_prefix=True, group=None):
+def send_email(poster, to, text, subject, use_prefix=True, group=None):
     """
     Sends an email to a user. Expects 'to' to be a comma separated string of
     emails, and for 'msg' and 'subject' to be strings. If group
@@ -13,7 +13,7 @@ def send_email(to, text, subject, use_prefix=True, group=None):
         subject = '[ASCIT Donut] ' + subject
 
     msg['Subject'] = subject
-    msg['From'] = 'auto@donut.caltech.edu'
+    msg['From'] = poster + '<auto@donut.caltech.edu>'
     if group:
         msg['To'] = group.lower().replace(' ', '_')
     else:

--- a/donut/modules/directory_search/templates/directory_search.html
+++ b/donut/modules/directory_search/templates/directory_search.html
@@ -74,9 +74,7 @@
 					$('<a>').attr('href', '/1/users/' + String(user.user_id)).text(user.full_name)
 				)
 			})
-			document.addEventListener("click", function() {
-                                nameSearch.children().remove()
-                        })
+			$(document).click(function() { nameSearch.empty() })
 		})
 	</script>
 {% endblock %}

--- a/donut/modules/directory_search/templates/directory_search.html
+++ b/donut/modules/directory_search/templates/directory_search.html
@@ -74,6 +74,9 @@
 					$('<a>').attr('href', '/1/users/' + String(user.user_id)).text(user.full_name)
 				)
 			})
+			document.addEventListener("click", function() {
+                                nameSearch.children().remove()
+                        })
 		})
 	</script>
 {% endblock %}

--- a/donut/modules/feedback/helpers.py
+++ b/donut/modules/feedback/helpers.py
@@ -9,12 +9,12 @@ def send_update_email(group, email, complaint_id):
     '''
     Sends an email to [email] of poster and group
     '''
-    EMAIL = "{}@donut.caltech.edu".format(group)
     msg = email_templates.added_message.format(group,
                                                get_link(group, complaint_id))
     subject = "Received {} Feedback".format(group)
     try:
-        email_utils.send_email(email, msg, subject, group=group)
+        email_utils.send_email(
+            "{} Feedback".format(group), email, msg, subject, group=group)
         return True
     except:
         return False

--- a/donut/modules/feedback/helpers.py
+++ b/donut/modules/feedback/helpers.py
@@ -13,8 +13,7 @@ def send_update_email(group, email, complaint_id):
                                                get_link(group, complaint_id))
     subject = "Received {} Feedback".format(group)
     try:
-        email_utils.send_email(
-            "{} Feedback".format(group), email, msg, subject, group=group)
+        email_utils.send_email(email, msg, subject, group=group)
         return True
     except:
         return False

--- a/donut/modules/newsgroups/helpers.py
+++ b/donut/modules/newsgroups/helpers.py
@@ -156,7 +156,11 @@ def send_email(data):
         return True
     try:
         email_utils.send_email(
-            emails, data['msg'], data['subject'], group=data['group'])
+            data['poster'],
+            emails,
+            data['msg'],
+            data['subject'],
+            group=data['group_name'])
         return True
     except smtplib.SMTPException:
         return False

--- a/donut/modules/newsgroups/helpers.py
+++ b/donut/modules/newsgroups/helpers.py
@@ -156,11 +156,11 @@ def send_email(data):
         return True
     try:
         email_utils.send_email(
-            data['poster'],
             emails,
             data['msg'],
             data['subject'],
-            group=data['group_name'])
+            group=data['group_name'],
+            poster=data['poster'])
         return True
     except smtplib.SMTPException:
         return False

--- a/donut/modules/newsgroups/routes.py
+++ b/donut/modules/newsgroups/routes.py
@@ -13,9 +13,7 @@ def newsgroups_home():
     if 'username' not in flask.session:
         return flask.abort(403)
     return flask.render_template(
-        'newsgroups.html',
-        groups=helpers.get_newsgroups(),
-        page_title="All Newsgroups")
+        'newsgroups.html', groups=helpers.get_newsgroups(), page="all")
 
 
 @blueprint.route('/newsgroups/post')
@@ -29,7 +27,8 @@ def post(group_id=None):
     return flask.render_template(
         'post.html',
         groups=helpers.get_my_newsgroups(user_id, True),
-        group_selected=group_id)
+        group_selected=group_id,
+        page='post')
 
 
 @blueprint.route('/newsgroups/postmessage', methods=['POST'])
@@ -116,7 +115,7 @@ def mygroups():
     return flask.render_template(
         'newsgroups.html',
         groups=helpers.get_my_newsgroups(user_id),
-        page_title="My Newsgroups")
+        page="my")
 
 
 @blueprint.route('/newsgroups/viewmsg/<post_id>')

--- a/donut/modules/newsgroups/templates/navbar.html
+++ b/donut/modules/newsgroups/templates/navbar.html
@@ -2,9 +2,9 @@
 <div role="group">
 <div id="newsgroup-nav-bar">
 <h1>Newsgroup Services</h1>
-<a href={{ url_for("newsgroups.newsgroups_home") }} class="btn btn-default">All Groups</a>
-<a href={{ url_for("newsgroups.mygroups") }} class="btn btn-default">My Groups</a>
-<a href={{ url_for("newsgroups.post") }} class="btn btn-default">Post Message</a>
+<a href={{ url_for("newsgroups.newsgroups_home") }} class="btn btn-primary {% if page == 'all' %} active {% endif %}">All Groups</a>
+<a href={{ url_for("newsgroups.mygroups") }} class="btn btn-primary {% if page == 'my' %} active {% endif %}">My Groups</a>
+<a href={{ url_for("newsgroups.post") }} class="btn btn-primary {% if page == 'post' %} active {% endif %}">Post Message</a>
 </div>
 </div>
 </div>

--- a/donut/modules/newsgroups/templates/newsgroups.html
+++ b/donut/modules/newsgroups/templates/newsgroups.html
@@ -3,7 +3,6 @@
 {% include "navbar.html" %}
 <div class="container theme-showcase" role="main">
   <div class="newsgroup-frame">
-    <h3>{{page_title}}</h3>
 	{% for group in groups %}
 	<a href={{ url_for(".view_group", group_id=group["group_id"]) }}>{{ group["group_name"] }}</a>
 	<br>


### PR DESCRIPTION
### Summary
- replaced page_title with highlighting the button on the page selected for newsgroups
- fixed the to email to use the group name not id
- use poster name as from in emails (e.g. "ug Admin")
- fixed directory search to allow closing the dropdown (fixes #150)