### PR TITLE
Add page to manage house members

### DIFF
--- a/donut/auth_utils.py
+++ b/donut/auth_utils.py
@@ -335,12 +335,18 @@ def get_permissions(username):
     return set(row['permission_id'] for row in result)
 
 
-def check_permission(username, permission_id):
+def check_permission(username, permission_ids):
     """
-    Returns True if the user has this permission, otherwise False
+    Returns the permissions among permission_ids that the current user has.
+    permission_ids should either be a single permission_id or a iterable of them.
     """
+    if isinstance(permission_ids, (list, tuple)):
+        permission_ids = set(permission_ids)
+    elif not isinstance(permission_ids, set):
+        permission_ids = set((permission_ids, ))
     permissions = get_permissions(username)
-    return permission_id in permissions or Permissions.ADMIN in permissions
+    return permission_ids if Permissions.ADMIN in permissions \
+        else permission_ids & permissions
 
 
 def is_caltech_user():

--- a/donut/modules/calendar/helpers.py
+++ b/donut/modules/calendar/helpers.py
@@ -388,15 +388,12 @@ def get_permission():
     '''
     Returns permissions list related to calendars
     '''
-    perms = {}
+    permissions = auth_utils.check_permission(
+        flask.session.get('username'), set(cal_permissions.values()))
+    perms = {tag: perm in permissions for tag, perm in cal_permissions.items()}
     # If they have edit permissions on anything, the events pages and stuff
     # will show up.
-    anyy = False
-    username = flask.session.get('username')
-    for tag, perm in cal_permissions.items():
-        perms[tag] = auth_utils.check_permission(username, perm)
-        anyy = perms[tag] or anyy
-    perms['Any'] = anyy
+    perms['Any'] = bool(permissions)
     return perms
 
 

--- a/donut/modules/directory_search/permissions.py
+++ b/donut/modules/directory_search/permissions.py
@@ -1,5 +1,16 @@
 import enum
 
 
-class Directory_Permissions(enum.IntEnum):
+class DirectoryPermissions(enum.IntEnum):
     HIDDEN_SEARCH_FIELDS = 3
+
+
+class ManageMembersPermissions(enum.IntEnum):
+    AVERY = 34
+    BLACKER = 35
+    DABNEY = 36
+    FLEMING = 37
+    LLOYD = 38
+    PAGE = 39
+    RICKETTS = 40
+    RUDDOCK = 41

--- a/donut/modules/directory_search/templates/directory_search.html
+++ b/donut/modules/directory_search/templates/directory_search.html
@@ -1,6 +1,10 @@
 {% extends 'layout.html' %}
 {% block page %}
 	<div class='container theme-showcase jumbotron'>
+		{% if manage_members_houses %}
+			<a href='{{ url_for(".manage_members") }}'>Manage house members</a>
+		{% endif %}
+
 		<h2>Directory Search</h2>
 		<h4>I'm looking for someone...</h4>
 		<form action='{{ url_for("directory_search.search") }}' method='POST'>

--- a/donut/modules/directory_search/templates/manage_house_members.html
+++ b/donut/modules/directory_search/templates/manage_house_members.html
@@ -1,0 +1,77 @@
+{% extends 'layout.html' %}
+{% block page %}
+  <div class='container theme-showcase' role='main'>
+    <div class='jumbotron'>
+      {% for house in manage_houses %}
+        <div class='panel panel-default'>
+          <div class='panel-heading'>
+            <h1>Manage {{ house }} members</h1>
+          </div>
+          <div class='panel-body'>
+            <div class='row'>
+              {% for member_type in house_members[house] %}
+                <div class='col-md-{{ 12 // house_members[house]|length }}'>
+                  {% set member_type_name = member_type['pos_name'].lower() %}
+                  <h3>Add a {{ member_type_name }}</h3>
+                  <form action='{{ url_for(".add_member", pos_id=member_type["pos_id"]) }}' method='POST'>
+                    <div class='form-group'>
+                      <label class='required' for='{{ house }}_name'>New member:</label>
+                      <input class='form-control name' id='{{ house }}_name' placeholder='Type a name...' />
+                      <ul class='list-group name-search'></ul>
+                      <input type='hidden' class='user' name='user_id' />
+                    </div>
+                    <button class='btn btn-primary'>Add {{ member_type_name }}</button>
+                  </form>
+
+                  <h3>Current {{ member_type_name }}s</h3>
+                  <table class='table table-condensed table-striped'>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Remove</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for member in member_type['members'] %}
+                        <tr>
+                          <td>
+                            <a href='{{ url_for(".view_user", user_id=member["user_id"]) }}'>
+                              {{ member['full_name'] }}
+                            </a>
+                          </td>
+                          <td>
+                            <a class='btn btn-danger' href='{{ url_for(".remove_member", hold_id=member["hold_id"]) }}'>
+                              <span class='glyphicon glyphicon-remove'></span>
+                            </a>
+                          </td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script src='{{ url_for("static", filename="js/search-directory.js") }}'></script>
+  <script>
+    $('input.name').each(function() {
+      var $this = $(this)
+      var nameSearch = $this.siblings('.name-search')
+      attachDirectorySearch($this, nameSearch, function(user) {
+        return $('<li>').addClass('list-group-item').text(user.full_name)
+          .click(function() {
+            $this.val(user.full_name)
+            $this.siblings('.user').val(user.user_id)
+            nameSearch.empty()
+          })
+      })
+    })
+  </script>
+{% endblock %}

--- a/donut/modules/groups/utils/insert_permissions.py
+++ b/donut/modules/groups/utils/insert_permissions.py
@@ -1,129 +1,131 @@
 import argparse
 from donut.pymysql_connection import make_db
-from donut.modules.auth.permissions import Permissions as auth_permissions
+from donut.default_permissions import Permissions
 from donut.modules.calendar.permissions import calendar_permissions
-from donut.modules.directory_search.permissions import Directory_Permissions as directory_permissions
+from donut.modules.directory_search.permissions import ManageMembersPermissions
 from donut.modules.editor.edit_permission import EditPermission as page_edit_permissions
 from donut.modules.feedback.permissions import BOD_PERMISSIONS as bod_permissions, ARC_PERMISSIONS as arc_permissions, DONUT_PERMISSIONS as donut_permissions
 from donut.modules.uploads.upload_permission import UploadPermissions as upload_permissions
 from donut.modules.voting.permissions import Permissions as voting_permissions
 
-valid_permissions = {
+# Permissions to assign to all positions in a group with a given control value.
+# True means that a position has control over that group.
+groups_permissions = {
     "Devteam":
     {
-        # True means that a position has control over that group.
-        True: [1], # All
-        False: [1] # All
+        True: [Permissions.ADMIN], # All
+        False: [Permissions.ADMIN] # All
     },
     "IHC":
     {
         # Editing Pages, Upload documents
-        True: [page_edit_permissions.ABLE.value, upload_permissions.ABLE.value],
+        True: [page_edit_permissions.ABLE, upload_permissions.ABLE],
         # Editing Pages, Upload documents
-        False: [page_edit_permissions.ABLE.value, upload_permissions.ABLE.value]
+        False: [page_edit_permissions.ABLE, upload_permissions.ABLE]
     },
     "ASCIT":
     {   # Editing Pages, Upload documents, View Bodfeedback summary,
         # Edit Bodfeedback, Edit Bodfeedback emails, View Bodfeedback emails
         True: [
-                page_edit_permissions.ABLE.value,
-                upload_permissions.ABLE.value,
-                bod_permissions.SUMMARY.value,
-                bod_permissions.TOGGLE_READ.value,
-                bod_permissions.ADD_REMOVE_EMAIL.value,
-                bod_permissions.VIEW_EMAILS.value,
+                page_edit_permissions.ABLE,
+                upload_permissions.ABLE,
+                bod_permissions.SUMMARY,
+                bod_permissions.TOGGLE_READ,
+                bod_permissions.ADD_REMOVE_EMAIL,
+                bod_permissions.VIEW_EMAILS,
             # All the calendars
-                calendar_permissions.ASCIT.value,
-                calendar_permissions.AVERY.value,
-                calendar_permissions.BECHTEL.value,
-                calendar_permissions.BLACKER.value,
-                calendar_permissions.DABNEY.value,
-                calendar_permissions.FLEMING.value,
-                calendar_permissions.LLOYD.value,
-                calendar_permissions.PAGE.value,
-                calendar_permissions.RICKETTS.value,
-                calendar_permissions.RUDDOCK.value,
-                calendar_permissions.OTHER.value,
-                calendar_permissions.ATHLETICS.value,
+                calendar_permissions.ASCIT,
+                calendar_permissions.AVERY,
+                calendar_permissions.BECHTEL,
+                calendar_permissions.BLACKER,
+                calendar_permissions.DABNEY,
+                calendar_permissions.FLEMING,
+                calendar_permissions.LLOYD,
+                calendar_permissions.PAGE,
+                calendar_permissions.RICKETTS,
+                calendar_permissions.RUDDOCK,
+                calendar_permissions.OTHER,
+                calendar_permissions.ATHLETICS,
                 # Surveys
-                voting_permissions.SURVEYS.value
+                voting_permissions.SURVEYS
             ],
         # View Bodfeedback summary, Edit Bodfeedback, View Bodfeedback emails
         False: [
-                bod_permissions.SUMMARY.value,
-                bod_permissions.TOGGLE_READ.value,
-                bod_permissions.VIEW_EMAILS.value,
+                bod_permissions.SUMMARY,
+                bod_permissions.TOGGLE_READ,
+                bod_permissions.VIEW_EMAILS,
                 # Surveys
-                voting_permissions.SURVEYS.value]
+                voting_permissions.SURVEYS]
     },
     "Academics and Research Committee (ARC)":
     {
         # View Arcfeedback summary, Edit Arcfeedback, Edit Arcfeedback emails
         # View Arcfeedback emails, Surveys
         True: [
-                arc_permissions.SUMMARY.value,
-                arc_permissions.TOGGLE_READ.value,
-                arc_permissions.ADD_REMOVE_EMAIL.value,
-                arc_permissions.VIEW_EMAILS.value,
-                voting_permissions.SURVEYS.value],
+                arc_permissions.SUMMARY,
+                arc_permissions.TOGGLE_READ,
+                arc_permissions.ADD_REMOVE_EMAIL,
+                arc_permissions.VIEW_EMAILS,
+                voting_permissions.SURVEYS],
         # View Arcfeedback summary, Edit Arcfeedback, View Arcfeedback emails,
         # Surveys
-        False: [arc_permissions.SUMMARY.value,
-                arc_permissions.TOGGLE_READ.value,
-                arc_permissions.VIEW_EMAILS.value,
-                voting_permissions.SURVEYS.value],
+        False: [arc_permissions.SUMMARY,
+                arc_permissions.TOGGLE_READ,
+                arc_permissions.VIEW_EMAILS,
+                voting_permissions.SURVEYS],
     },
     "Avery":
-    {   # Edit Avery Calendar
-        True: [calendar_permissions.AVERY.value],
+    {
+        # Edit Avery Calendar, Manage Avery members
+        True: [calendar_permissions.AVERY, ManageMembersPermissions.AVERY],
     },
     "Blacker":
     {
-        # Edit Blacker Calendar
-        True: [calendar_permissions.BLACKER.value],
+        # Edit Blacker Calendar, Manage Blacker members
+        True: [calendar_permissions.BLACKER, ManageMembersPermissions.BLACKER],
     },
     "Dabney":
     {
-        # Edit Dabney Calendar
-        True: [calendar_permissions.DABNEY.value],
+        # Edit Dabney Calendar, Manage Dabney members
+        True: [calendar_permissions.DABNEY, ManageMembersPermissions.DABNEY],
     },
     "Fleming":
     {
-        # Edit Fleming Calendar
-        True: [calendar_permissions.FLEMING.value],
+        # Edit Fleming Calendar, Manage Fleming members
+        True: [calendar_permissions.FLEMING, ManageMembersPermissions.FLEMING],
     },
     "Lloyd":
     {
-        # Edit LLoyd Calendar
-        True: [calendar_permissions.LLOYD.value],
+        # Edit LLoyd Calendar, Manage Lloyd members
+        True: [calendar_permissions.LLOYD, ManageMembersPermissions.LLOYD],
     },
     "Page":
     {
-        # Edit Page Calendar
-        True: [calendar_permissions.PAGE.value],
+        # Edit Page Calendar, Manage Page members
+        True: [calendar_permissions.PAGE, ManageMembersPermissions.PAGE],
     },
     "Ricketts":
     {
-        # Edit Ricketts Calendar
-        True: [calendar_permissions.RICKETTS.value],
+        # Edit Ricketts Calendar, Manage Ricketts members
+        True: [calendar_permissions.RICKETTS, ManageMembersPermissions.RICKETTS],
     },
     "Ruddock":
     {
-        # Edit Ruddock Calendar
-        True: [calendar_permissions.RUDDOCK.value],
+        # Edit Ruddock Calendar, Manage Ruddock members
+        True: [calendar_permissions.RUDDOCK, ManageMembersPermissions.RUDDOCK],
     },
     "Bechtel":
     {
         # Edit Bechtel Calendar
-        True: [calendar_permissions.BECHTEL.value],
+        True: [calendar_permissions.BECHTEL],
     },
     "Review Committee":
     {
         # Editing Pages, Upload documents, Surveys
         True: [
-                page_edit_permissions.ABLE.value,
-                upload_permissions.ABLE.value,
-                voting_permissions.SURVEYS.value]
+                page_edit_permissions.ABLE,
+                upload_permissions.ABLE,
+                voting_permissions.SURVEYS]
     }
 }
 
@@ -132,30 +134,39 @@ def insert_permissions(env):
     db = make_db(env)
     try:
         db.begin()
-        query = '''INSERT INTO position_permissions(pos_id, permission_id)
-            VALUES (%s, %s) '''
-        for group, group_permissions in valid_permissions.items():
-            for control, permission_ids in group_permissions.items():
-                position_ids = get_position_id(group, control, db)
-                for position_id in position_ids:
-                    for permission_id in permission_ids:
-                        with db.cursor() as cursor:
-                            cursor.execute(query, [position_id, permission_id])
+        with db.cursor() as cursor:
+            for group, group_permissions in groups_permissions.items():
+                for control, permission_ids in group_permissions.items():
+                    for position in get_positions(group, control, cursor):
+                        for permission_id in permission_ids:
+                            if add_permission(position['pos_id'],
+                                              permission_id.value, cursor):
+                                print(
+                                    f'Granted "{permission_id.name}" to group "{group}" position "{position["pos_name"]}"'
+                                )
         db.commit()
     finally:
         db.close()
 
 
-def get_position_id(group_name, control, db):
+def get_positions(group_name, control, cursor):
     query = '''
-        SELECT pos_id
-            FROM groups NATURAL JOIN positions
-            WHERE group_name = %s and control = %s
-        '''
-    with db.cursor() as cursor:
-        cursor.execute(query, [group_name, control])
-        res = cursor.fetchall()
-    return [result["pos_id"] for result in res]
+        SELECT pos_id, pos_name
+        FROM groups NATURAL JOIN positions
+        WHERE group_name = %s AND control = %s
+    '''
+    cursor.execute(query, (group_name, control))
+    return cursor.fetchall()
+
+
+def add_permission(position_id, permission_id, cursor):
+    query = """
+        INSERT INTO position_permissions(pos_id, permission_id)
+        VALUES (%s, %s)
+        ON DUPLICATE KEY UPDATE pos_id = pos_id
+    """
+    cursor.execute(query, (position_id, permission_id))
+    return cursor.rowcount > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
- Added a house member management page with a link to it from the directory search page (fixed #152)
- Secretaries have permissions to access this page for their respective houses
- Made `check_permission()` support checking multiple permissions at the same time
- Improve permission import script (ignore duplicates, print results, etc.)

### Test Plan
- Tests are passing; I grepped for all usages of `check_permission()` to make sure I wasn't breaking them
- **I need to remember to run `insert_permissions.py` against prod once this is merged in**
