### PR TITLE
Display newlines on feedback and newsgroup posts

### DIFF
--- a/donut/modules/feedback/templates/complaint.html
+++ b/donut/modules/feedback/templates/complaint.html
@@ -66,7 +66,7 @@
                         <tr>
                             <th>{{ message['time'].strftime('%b %d %Y %-I:%M%p') }}</th>
                             <th>{{ message['poster'] }}</th>
-                            <td>{{ message['message'] }}</td>
+                            <td style="white-space: pre-wrap">{{ message['message'] }}</td>
                         </tr>
                         {% endfor %}
                    </table>

--- a/donut/modules/newsgroups/templates/view_post.html
+++ b/donut/modules/newsgroups/templates/view_post.html
@@ -13,7 +13,7 @@
 		<h3>Date: {{ post.time_sent }}</h3>
 		<h3>Subject: {{ post.subject }}</h3>
 		<h3>Message:</h3>
-		<h4>{{ post.message }}</h4>
+		<h4 style="white-space: pre-wrap">{{ post.message }}</h4>
 </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Multiple-line messages were being squished onto a single line, making them hard to read