### PR TITLE
ug-* admins shouldn't receive emails for the group

### DIFF
--- a/donut/modules/directory_search/utils/update_ug_groups.py
+++ b/donut/modules/directory_search/utils/update_ug_groups.py
@@ -89,8 +89,8 @@ def make_ug_year_groups(cursor, group_type, ug_admin_positions):
         VALUES (%s, 'Member')
     """
     make_admin_position_query = """
-        INSERT INTO positions(group_id, pos_name, send, control)
-        VALUES (%s, 'Admin', TRUE, TRUE)
+        INSERT INTO positions(group_id, pos_name, send, control, receive)
+        VALUES (%s, 'Admin', TRUE, TRUE, FALSE)
     """
     add_admin_relation_query = """
         INSERT INTO position_relations(pos_id_from, pos_id_to) VALUES (%s, %s)


### PR DESCRIPTION
Minor fix, just prevents ug group admins from receiving emails sent to the group if they aren't also members. They should still be able to see the messages on Donut. I already made the changes to the prod DB.