### PR TITLE
Planner improvements

### DIFF
--- a/donut/modules/courses/routes.py
+++ b/donut/modules/courses/routes.py
@@ -71,12 +71,64 @@ def planner_drop_course(course_id, year):
     return flask.jsonify({'success': True})
 
 
+@blueprint.route('/1/planner/<int:year>/<int:term>/placeholder', \
+    methods=('POST', ))
+def planner_add_placeholder(year, term):
+    username = flask.session.get('username')
+    if not username:
+        return flask.jsonify({
+            'success': False,
+            'message': 'Must be logged in to save'
+        })
+    form = flask.request.form
+    course = form.get('course')
+    units = form.get('units')
+    if not (course and units):
+        return flask.jsonify({
+            'success': False,
+            'message': 'Missing course or units'
+        })
+    try:
+        units = float(units)
+    except ValueError:
+        return flask.jsonify({
+            'success': False,
+            'message': 'Invalid number of units'
+        })
+
+    placeholder_id = \
+        helpers.add_planner_placeholder(username, year, term, course, units)
+    return flask.jsonify({'success': True, 'id': placeholder_id})
+
+
+@blueprint.route('/1/planner/placeholder/<int:id>', methods=('DELETE', ))
+def planner_drop_placeholder(id):
+    username = flask.session.get('username')
+    if not username:
+        return flask.jsonify({
+            'success': False,
+            'message': 'Must be logged in to save'
+        })
+    if not helpers.drop_planner_placeholder(username, id):
+        return flask.jsonify({
+            'success': False,
+            'message': 'Invalid placeholder'
+        })
+
+    return flask.jsonify({'success': True})
+
+
 @blueprint.route('/1/planner/courses/mine')
 def planner_mine():
     username = flask.session.get('username')
     if not username: return flask.jsonify(())
 
-    return flask.jsonify(helpers.get_user_planner_courses(username))
+    return flask.jsonify({
+        'courses':
+        helpers.get_user_planner_courses(username),
+        'placeholders':
+        helpers.get_user_planner_placeholders(username)
+    })
 
 
 @blueprint.route('/1/scheduler/courses/<int:year>/<int:term>')

--- a/donut/modules/courses/templates/planner.html
+++ b/donut/modules/courses/templates/planner.html
@@ -212,21 +212,26 @@
   <script src='{{ url_for("static", filename="js/courses/search.js") }}'></script>
   <script>
     var SHOW_COURSES = 50
-    var HSS_DEPARTMENTS = {
-      An: true,
-      BEM: true,
-      Ec: true,
+    var HUMANITIES_DEPARTMENTS = {
       En: true,
       H: true,
       HPS: true,
       Hum: true,
-      L: true,
-      Law: true,
       Mu: true,
       Pl: true,
+      VC: true
+    }
+    var SOCIAL_SCIENCE_DEPARTMENTS = {
+      An: true,
+      BEM: true,
+      Ec: true,
+      Law: true,
       PS: true,
       Psy: true,
-      SS: true,
+      SS: true
+    }
+    var MISC_HSS_DEPARTMENTS = {
+      L: true,
       Wr: true
     }
 
@@ -483,7 +488,7 @@
           menu = false,
           Ch3 = false, labUnits = 0,
           PE = 0,
-          hums = 0
+          humanities = 0, socialSciences = 0, hss = 0
       termLists.each(function() {
         $(this).children('.course').each(function() {
           var $this = $(this)
@@ -527,20 +532,24 @@
             case 'Ph 5':
             case 'Ph 8b':
             case 'Ph 8c':
-              labUnits += units
-              break
+              labUnits += units; break
             default:
               if (courseName.startsWith('PE ')) PE++
               else if (units >= 9) {
-                var depts = courseName.split(' ')[0].split('/')
-                var hss = false
-                for (let i = 0; i < depts.length; i++) {
-                  if (HSS_DEPARTMENTS[depts[i]]) {
-                    hss = true
-                    break
-                  }
-                }
-                if (hss) hums++
+                var departments = courseName.split(' ')[0].split('/')
+                var isHumanity = departments.some(function(department) {
+                  return department in HUMANITIES_DEPARTMENTS
+                })
+                if (isHumanity) humanities++
+                var isSocialScience = departments.some(function(department) {
+                  return department in SOCIAL_SCIENCE_DEPARTMENTS
+                })
+                if (isSocialScience) socialSciences++
+                var isHSS = isHumanity || isSocialScience ||
+                  departments.some(function(department) {
+                    return department in MISC_HSS_DEPARTMENTS
+                  })
+                if (isHSS) hss++
               }
           }
         })
@@ -553,7 +562,9 @@
       $('.progress-bar#menu').css('width', menu * 100 + '%')
       $('.progress-bar#ch3').css('width', Ch3 * 100 + '%')
       $('.progress-bar#add-lab').css('width', Math.min(labUnits / 6, 1) * 100 + '%')
-      $('.progress-bar#hums').css('width', Math.min(hums / 12, 1) * 100 + '%')
+      $('.progress-bar#hums')
+        .text('Humanities: ' + String(humanities) + '; Social sciences: ' + String(socialSciences))
+        .css('width', Math.min(hss / 12, 1) * 100 + '%')
       $('.progress-bar#pe').css('width', Math.min(PE / 3, 1) * 100 + '%')
     }
     function setCoursesHeight() {

--- a/donut/modules/courses/templates/planner.html
+++ b/donut/modules/courses/templates/planner.html
@@ -112,6 +112,7 @@
   <style>
     #warning {
       float: right;
+      margin-bottom: 0;
     }
     #course-results, #courses-pane {
       overflow-y: auto;
@@ -279,8 +280,21 @@
       addUnits(courseList, units)
       return courseItem
     }
-    var draggedCourse = null
-    function addCourse(course, courseList, skipAPIAdd) {
+    var draggedCourse = null, draggedCourseItem = null
+    function makeDraggable(element, removeWhenDragged, getCourse) {
+      element.attr('draggable', 'true')
+        .on('dragstart', function(e) {
+          // Needed for Firefox
+          var event = e.originalEvent
+          event.dataTransfer.setData('text/plain', null)
+          event.dropEffect = 'move'
+
+          draggedCourse = getCourse()
+          draggedCourseItem = removeWhenDragged ? $(this) : null
+        })
+        .on('dragend', function() { draggedCourse = null })
+    }
+    function addCourse(courseList, course, oldCourseItem, skipAPIAdd) {
       var yearTerm = getYearTerm(courseList)
       var year = yearTerm[0], term = yearTerm[1]
       var termIndex = course.terms.indexOf(term)
@@ -308,6 +322,12 @@
           }
         })
       })
+      makeDraggable(courseItem, true, function() {
+        for (var i = 0; i < courses.length; i++) {
+          if (courses[i].number === course.number) return courses[i]
+        }
+        return course
+      })
       if (skipAPIAdd) return
 
       displayWarning('Saving...')
@@ -316,7 +336,11 @@
         url: '/1/planner/course/' + id + '/add/' + String(year),
         dataType: 'json',
         success: function(response) {
-          if (response.success) displayWarning('')
+          if (response.success) {
+            // Remove the course from its old term if necessary
+            if (oldCourseItem) oldCourseItem.find('button').click()
+            else displayWarning('')
+          }
           else {
             displayWarning(response.message)
             courseItem.remove()
@@ -350,34 +374,47 @@
       courseInput.focus()
 
       function savePlaceholder() {
-        displayWarning('Saving...')
-        var yearTerm = getYearTerm(courseList)
-        var course = courseInput.val()
-        var units = Number(unitsInput.val())
-        $.ajax({
-          type: 'POST',
-          url: '/1/planner/' + yearTerm.join('/') + '/placeholder',
-          data: {course: course, units: units},
-          dataType: 'json',
-          success: function(response) {
-            if (response.success) {
-              displayWarning('')
-              placeholder.remove()
-              var placeholderID = response.id
-              var courseItem = addCourseOrPlaceholder(courseList, course, units, function() {
-                dropPlaceholder(courseItem, placeholderID)
-              })
-            }
-            else displayWarning(response.message)
-          },
-          error: function() {
-            displayWarning('Failed to add placeholder')
-          }
-        })
+        addPlaceholder(
+          courseList,
+          courseInput.val(),
+          Number(unitsInput.val()),
+          placeholder
+        )
       }
       function saveOnEnter(e) {
         if (e.which === 13) savePlaceholder()
       }
+    }
+    function displayPlaceholder(courseList, course, units, placeholderID) {
+      var courseItem = addCourseOrPlaceholder(courseList, course, units, function() {
+        dropPlaceholder(courseItem, placeholderID)
+      })
+      makeDraggable(courseItem, true, function() {
+        return {placeholder: true, course: course, units: units}
+      })
+    }
+    function addPlaceholder(courseList, course, units, placeholder, oldCourseItem) {
+      var yearTerm = getYearTerm(courseList)
+      displayWarning('Saving...')
+      $.ajax({
+        type: 'POST',
+        url: '/1/planner/' + yearTerm.join('/') + '/placeholder',
+        data: {course: course, units: units},
+        dataType: 'json',
+        success: function(response) {
+          if (response.success) {
+            // Remove the previous location of this placeholder
+            if (placeholder) placeholder.remove()
+            if (oldCourseItem) oldCourseItem.find('button').click()
+            else displayWarning('')
+            displayPlaceholder(courseList, course, units, response.id)
+          }
+          else displayWarning(response.message)
+        },
+        error: function() {
+          displayWarning('Failed to add placeholder')
+        }
+      })
     }
     function dropPlaceholder(placeholder, id) {
       displayWarning('Saving...')
@@ -424,19 +461,8 @@
             {% endfor %}
           }
         })
-        courseItem
-          .attr('draggable', 'true')
-          .on('dragstart', function(e) {
-            // Needed for Firefox
-            var event = e.originalEvent
-            event.dataTransfer.setData('text/plain', null)
-            event.dropEffect = 'move'
-
-            draggedCourse = course
-          })
-          .on('dragend', function() { draggedCourse = null })
-          .append(termsList)
-        coursesList.append(courseItem)
+        makeDraggable(courseItem, false, function() { return course })
+        coursesList.append(courseItem.append(termsList))
       })
     }
     function displayWarning(message) {
@@ -463,15 +489,14 @@
       dataType: 'json',
       success: function(courses) {
         courses.courses.forEach(function(course) {
-          addCourse(course, getTermCoursesList(course.year, course.terms[0]), true)
+          addCourse(getTermCoursesList(course.year, course.terms[0]), course, null, true)
         })
         courses.placeholders.forEach(function(placeholder) {
-          var courseList = getTermCoursesList(placeholder.year, placeholder.term)
-          var courseItem = addCourseOrPlaceholder(
-            courseList,
+          displayPlaceholder(
+            getTermCoursesList(placeholder.year, placeholder.term),
             placeholder.course,
             placeholder.units,
-            function() { dropPlaceholder(courseItem, placeholder.id) }
+            placeholder.id
           )
         })
       },
@@ -585,7 +610,17 @@
         })
         .on('drop', function(e) {
           e.preventDefault() // stops some browsers from redirecting
-          addCourse(draggedCourse, $(this).children('.term-courses-list'))
+          var courseList = $(this).children('.term-courses-list')
+          if (draggedCourse.placeholder) {
+            addPlaceholder(
+              courseList,
+              draggedCourse.course,
+              draggedCourse.units,
+              null,
+              draggedCourseItem
+            )
+          }
+          else addCourse(courseList, draggedCourse, draggedCourseItem)
           draggedCourse = null
         })
       $('.add-placeholder').click(function() {

--- a/donut/modules/courses/templates/planner.html
+++ b/donut/modules/courses/templates/planner.html
@@ -31,7 +31,12 @@
                 {% for term in TERMS %}
                   <td class='term-courses'>
                     <ul class='list-group term-courses-list' year={{ year }} term={{ term }}>
-                      <li class='list-group-item term-units' units=0>0 units</li>
+                      <li class='list-group-item'>
+                        <span class='term-units' units=0>0 units</span>
+                        <button class='btn btn-default btn-xs add-placeholder'>
+                          <span class='glyphicon glyphicon-plus'></span>
+                        </button>
+                      </li>
                     </ul>
                   </td>
                 {% endfor %}
@@ -149,9 +154,11 @@
       padding: 0;
       font-size: 14px;
     }
+    .term-courses-list .list-group-item:last-child {
+      border: none;
+    }
     .term-units {
       font-weight: bold;
-      border: none;
     }
     #requirements-modal {
       position: fixed;
@@ -246,13 +253,26 @@
       return String(units) + ' unit' + (units === 1 ? '' : 's')
     }
     function getUnitsDisplay(courseList) {
-      return courseList.children('.term-units')
+      return courseList.find('.term-units')
     }
     function addUnits(courseList, units) {
       var unitsDisplay = getUnitsDisplay(courseList)
       var newUnits = Number(unitsDisplay.attr('units')) + units
       unitsDisplay.attr('units', newUnits)
       unitsDisplay.text(unitString(newUnits))
+    }
+    function addCourseOrPlaceholder(courseList, course, units, onDelete) {
+      var courseItem = $('<li>')
+        .addClass('list-group-item course')
+        .attr({course: course, units: units})
+        .append(
+          $('<span>').text(course + ' (' + unitString(units) + ')'),
+          $('<button>').addClass('btn btn-danger btn-xs').click(onDelete)
+            .append($('<span>').addClass('glyphicon glyphicon-trash'))
+        )
+      getUnitsDisplay(courseList).parent().before(courseItem)
+      addUnits(courseList, units)
+      return courseItem
     }
     var draggedCourse = null
     function addCourse(course, courseList, skipAPIAdd) {
@@ -264,38 +284,25 @@
       }
       var id = String(course.ids[termIndex])
       var units = courseUnits(course)
-      var courseItem = $('<li>').addClass('list-group-item').attr({course: course.number, units: units}).append(
-        $('<span>').text(
-          course.number + ' (' + unitString(units) + ')'
-        ),
-        $('<button>').addClass('btn btn-danger btn-xs')
-          .click(function() {
-            courseItem.remove()
-            addUnits(courseList, -units)
-            displayWarning('Saving...')
-            $.ajax({
-              type: 'GET',
-              url: '/1/planner/course/' + id + '/drop/' + String(year),
-              dataType: 'json',
-              success: function(response) {
-                if (response.success) displayWarning('')
-                else {
-                  displayWarning(response.message)
-                  courseList.append(courseItem)
-                  addUnits(courseList, units)
-                }
-              },
-              error: function() {
-                displayWarning('Failed to drop course ' + course.number)
-                courseList.append(courseItem)
-                addUnits(courseList, units)
-              }
-            })
-          })
-          .append($('<span>').addClass('glyphicon glyphicon-trash'))
-      )
-      getUnitsDisplay(courseList).before(courseItem)
-      addUnits(courseList, units)
+      var courseItem = addCourseOrPlaceholder(courseList, course.number, units, function() {
+        displayWarning('Saving...')
+        $.ajax({
+          type: 'GET',
+          url: '/1/planner/course/' + id + '/drop/' + String(year),
+          dataType: 'json',
+          success: function(response) {
+            if (response.success) {
+              displayWarning('')
+              courseItem.remove()
+              addUnits(courseList, -units)
+            }
+            else displayWarning(response.message)
+          },
+          error: function() {
+            displayWarning('Failed to drop course ' + course.number)
+          }
+        })
+      })
       if (skipAPIAdd) return
 
       displayWarning('Saving...')
@@ -315,6 +322,77 @@
           displayWarning('Failed to add course ' + course.number)
           courseItem.remove()
           addUnits(courseList, -units)
+        }
+      })
+    }
+    function newPlaceholder(courseList) {
+      var courseInput = $('<input>').addClass('form-control')
+        .attr({name: 'course', placeholder: 'Course'})
+        .keydown(saveOnEnter)
+      var unitsInput = $('<input>').addClass('form-control')
+        .attr({type: 'number', name: 'units', placeholder: 'Units'})
+        .keydown(saveOnEnter)
+      var placeholder = $('<li>').addClass('list-group-item').append(
+        $('<form>').append(
+          $('<div>').addClass('form-group').append(courseInput),
+          $('<div>').addClass('form-group').append(unitsInput),
+          $('<button>').attr('type', 'button').addClass('btn btn-success')
+            .click(savePlaceholder)
+            .append($('<span>').addClass('glyphicon glyphicon-ok'))
+        )
+      )
+      courseList.prepend(placeholder)
+      courseInput.focus()
+
+      function savePlaceholder() {
+        displayWarning('Saving...')
+        var yearTerm = getYearTerm(courseList)
+        var course = courseInput.val()
+        var units = Number(unitsInput.val())
+        $.ajax({
+          type: 'POST',
+          url: '/1/planner/' + yearTerm.join('/') + '/placeholder',
+          data: {course: course, units: units},
+          dataType: 'json',
+          success: function(response) {
+            if (response.success) {
+              displayWarning('')
+              placeholder.remove()
+              var placeholderID = response.id
+              var courseItem = addCourseOrPlaceholder(courseList, course, units, function() {
+                dropPlaceholder(courseItem, placeholderID)
+              })
+            }
+            else displayWarning(response.message)
+          },
+          error: function() {
+            displayWarning('Failed to add placeholder')
+          }
+        })
+      }
+      function saveOnEnter(e) {
+        if (e.which === 13) savePlaceholder()
+      }
+    }
+    function dropPlaceholder(placeholder, id) {
+      displayWarning('Saving...')
+      $.ajax({
+        type: 'DELETE',
+        url: '/1/planner/placeholder/' + String(id),
+        dataType: 'json',
+        success: function(response) {
+          if (response.success) {
+            displayWarning('')
+            addUnits(
+              placeholder.closest('.term-courses-list'),
+              -Number(placeholder.attr('units'))
+            )
+            placeholder.remove()
+          }
+          else displayWarning(response.message)
+        },
+        error: function() {
+          displayWarning('Failed to drop placeholder')
         }
       })
     }
@@ -358,6 +436,9 @@
     function displayWarning(message) {
       $('#warning').text(message).show()
     }
+    function getTermCoursesList(year, term) {
+      return $('.term-courses-list[year=' + String(year) + '][term=' + String(term) + ']')
+    }
     $.ajax({
       type: 'GET',
       url: '{{ url_for("courses.planner_courses") }}',
@@ -375,10 +456,17 @@
       url: '{{ url_for("courses.planner_mine") }}',
       dataType: 'json',
       success: function(courses) {
-        myCourses = courses
-        courses.forEach(function(course) {
-          var courseList = $('.term-courses-list[year=' + course.year + '][term=' + course.terms[0] + ']')
-          addCourse(course, courseList, true)
+        courses.courses.forEach(function(course) {
+          addCourse(course, getTermCoursesList(course.year, course.terms[0]), true)
+        })
+        courses.placeholders.forEach(function(placeholder) {
+          var courseList = getTermCoursesList(placeholder.year, placeholder.term)
+          var courseItem = addCourseOrPlaceholder(
+            courseList,
+            placeholder.course,
+            placeholder.units,
+            function() { dropPlaceholder(courseItem, placeholder.id) }
+          )
         })
       },
       error: function() {
@@ -396,7 +484,7 @@
           PE = 0,
           hums = 0
       termLists.each(function() {
-        $(this).children(':not(.term-units)').each(function() {
+        $(this).children('.course').each(function() {
           var $this = $(this)
           var courseName = $this.attr('course'),
             units = Number($this.attr('units'))
@@ -488,6 +576,9 @@
           addCourse(draggedCourse, $(this).children('.term-courses-list'))
           draggedCourse = null
         })
+      $('.add-placeholder').click(function() {
+        newPlaceholder($(this).closest('.term-courses-list'))
+      })
       $('#show-requirements').click(function() {
         setRequirementsProgress()
         requirementsModal.show()

--- a/donut/modules/courses/templates/planner.html
+++ b/donut/modules/courses/templates/planner.html
@@ -429,6 +429,7 @@
 
             draggedCourse = course
           })
+          .on('dragend', function() { draggedCourse = null })
           .append(termsList)
         coursesList.append(courseItem)
       })
@@ -586,9 +587,13 @@
       $('#close-requirements').click(function() {
         requirementsModal.hide()
       })
-      $('#search').keyup(function() {
-        displayCourses(searchCourses(courses, $(this).val()))
-      })
+      $('#search')
+        .keyup(function() {
+          displayCourses(searchCourses(courses, $(this).val()))
+        })
+        .on('drop', function(e) {
+          if (draggedCourse) e.preventDefault()
+        })
       setCoursesHeight()
       $(window).resize(setCoursesHeight)
     })

--- a/sql/courses.sql
+++ b/sql/courses.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS planner_courses;
+DROP TABLE IF EXISTS planner_placeholders;
 DROP TABLE IF EXISTS scheduler_sections;
 DROP TABLE IF EXISTS sections;
 DROP TABLE IF EXISTS courses;
@@ -56,6 +57,17 @@ CREATE TABLE planner_courses (
     FOREIGN KEY (user_id) REFERENCES members(user_id),
     FOREIGN KEY (course_id) REFERENCES courses(course_id)
         ON DELETE CASCADE
+);
+
+CREATE TABLE planner_placeholders (
+    placeholder_id  INT      NOT NULL AUTO_INCREMENT,
+    user_id         INT      NOT NULL,
+    planner_year    TINYINT  NOT NULL, -- Frosh: 1, ..., Senior: 4
+    term            TINYINT  NOT NULL, -- FA: 1, WI: 2, SP: 3
+    course_name     TEXT     NOT NULL,
+    course_units    FLOAT    NOT NULL,
+    PRIMARY KEY (placeholder_id),
+    FOREIGN KEY (user_id) REFERENCES members(user_id)
 );
 
 CREATE TABLE scheduler_sections (

--- a/tests/modules/courses/test_courses.py
+++ b/tests/modules/courses/test_courses.py
@@ -188,7 +188,7 @@ def test_planner_mine(client):
         sess['username'] = 'csander'
     rv = client.get(flask.url_for('courses.planner_mine'))
     assert rv.status_code == 200
-    assert json.loads(rv.data) == []
+    assert json.loads(rv.data) == {'courses': [], 'placeholders': []}
     # Test adding some courses
     rv = client.get(
         flask.url_for('courses.planner_add_course', course_id=1, year=2))
@@ -213,25 +213,28 @@ def test_planner_mine(client):
     # Test courses list now that courses have been added; verify order
     rv = client.get(flask.url_for('courses.planner_mine'))
     assert rv.status_code == 200
-    assert json.loads(rv.data) == [{
-        'ids': [1],
-        'number': 'CS 124',
-        'terms': [1],
-        'units': 12,
-        'year': 2
-    }, {
-        'ids': [6],
-        'number': 'Bi 1',
-        'terms': [3],
-        'units': 9,
-        'year': 1
-    }, {
-        'ids': [5],
-        'number': 'CS 38',
-        'terms': [3],
-        'units': 9,
-        'year': 1
-    }]
+    assert json.loads(rv.data) == {
+        'courses': [{
+            'ids': [1],
+            'number': 'CS 124',
+            'terms': [1],
+            'units': 12,
+            'year': 2
+        }, {
+            'ids': [6],
+            'number': 'Bi 1',
+            'terms': [3],
+            'units': 9,
+            'year': 1
+        }, {
+            'ids': [5],
+            'number': 'CS 38',
+            'terms': [3],
+            'units': 9,
+            'year': 1
+        }],
+        'placeholders': []
+    }
     # Test dropping a course
     rv = client.get(
         flask.url_for('courses.planner_drop_course', course_id=5, year=1))
@@ -239,19 +242,22 @@ def test_planner_mine(client):
     assert json.loads(rv.data) == {'success': True}
     rv = client.get(flask.url_for('courses.planner_mine'))
     assert rv.status_code == 200
-    assert json.loads(rv.data) == [{
-        'ids': [1],
-        'number': 'CS 124',
-        'terms': [1],
-        'units': 12,
-        'year': 2
-    }, {
-        'ids': [6],
-        'number': 'Bi 1',
-        'terms': [3],
-        'units': 9,
-        'year': 1
-    }]
+    assert json.loads(rv.data) == {
+        'courses': [{
+            'ids': [1],
+            'number': 'CS 124',
+            'terms': [1],
+            'units': 12,
+            'year': 2
+        }, {
+            'ids': [6],
+            'number': 'Bi 1',
+            'terms': [3],
+            'units': 9,
+            'year': 1
+        }],
+        'placeholders': []
+    }
 
 
 def test_scheduler_mine(client):


### PR DESCRIPTION
**Note to self**: need to run the `CREATE TABLE planner_placeholders ...` SQL on the prod DB

### Summary
- Can add placeholder courses in the planner. They look and act like normal courses, except they are stored in a new DB table. This should be useful in cases where a course is not offered in the current year, or the number of units is determined by the student. The UI is a little funky, maybe Logan wants to improve.
- Can drag courses and placeholders between terms to move them around. This is currently implemented by adding the course on the new term, and then deleting it from the old term if successful. Would be a little more efficient to do this in a single new API call, but using the existing APIs kept the code simpler.
- Core requirements now shows count of humanities and social sciences separately. Still not distinguishing intro, writing-intensive, and miscellaneous classes though.
- Fixed the save message shifting the planner up and down
- Fixed being able to drag courses onto the search bar

### Test Plan
- A lot of playing with the planner. There are a bunch of scenarios to test, but I think I got them all.