### PR TITLE
Don't remove ug-* groups

### DIFF
--- a/donut/modules/directory_search/helpers.py
+++ b/donut/modules/directory_search/helpers.py
@@ -69,6 +69,7 @@ def get_user(user_id):
             SELECT group_name, pos_name
             FROM current_position_holders NATURAL JOIN positions NATURAL JOIN groups
             WHERE pos_id NOT IN (SELECT pos_id FROM house_positions)
+            AND NOT (group_name LIKE 'ug-%%' AND pos_name = 'Admin')
             AND user_id = %s
         """
         with flask.g.pymysql_db.cursor() as cursor:


### PR DESCRIPTION
### Summary
- Keep `ug-*` graduation year groups and remove their members instead of removing the groups themselves. This fixes issues where groups can't be removed because newsgroup messages have been sent to them.
- All graduation years in Donut now have `ug-*` groups, not just the current 4 years
- `ug-*` admin positions are hidden in Directory since they are implied by the `ug` admin position

### Test Plan
- Ran the script in dev and prod and successfully updated the `ug-*` groups
