### PR TITLE
Fix the course planner when not logged in

### DIFF
--- a/donut/modules/courses/routes.py
+++ b/donut/modules/courses/routes.py
@@ -121,14 +121,13 @@ def planner_drop_placeholder(id):
 @blueprint.route('/1/planner/courses/mine')
 def planner_mine():
     username = flask.session.get('username')
-    if not username: return flask.jsonify(())
-
-    return flask.jsonify({
-        'courses':
-        helpers.get_user_planner_courses(username),
-        'placeholders':
-        helpers.get_user_planner_placeholders(username)
-    })
+    if username:
+        courses = helpers.get_user_planner_courses(username)
+        placeholders = helpers.get_user_planner_placeholders(username)
+    else:
+        courses = ()
+        placeholders = ()
+    return flask.jsonify({'courses': courses, 'placeholders': placeholders})
 
 
 @blueprint.route('/1/scheduler/courses/<int:year>/<int:term>')

--- a/donut/modules/courses/templates/planner.html
+++ b/donut/modules/courses/templates/planner.html
@@ -301,20 +301,23 @@
       if (termIndex < 0) {
         return alert('Class is not offered that term')
       }
+
+      // Remove the course from its old term if necessary
+      if (oldCourseItem) oldCourseItem.find('button').click()
+
+      // Display the new course
       var id = String(course.ids[termIndex])
       var units = courseUnits(course)
       var courseItem = addCourseOrPlaceholder(courseList, course.number, units, function() {
+        courseItem.remove()
+        addUnits(courseList, -units)
         displayWarning('Saving...')
         $.ajax({
           type: 'GET',
           url: '/1/planner/course/' + id + '/drop/' + String(year),
           dataType: 'json',
           success: function(response) {
-            if (response.success) {
-              displayWarning('')
-              courseItem.remove()
-              addUnits(courseList, -units)
-            }
+            if (response.success) displayWarning('')
             else displayWarning(response.message)
           },
           error: function() {
@@ -330,27 +333,21 @@
       })
       if (skipAPIAdd) return
 
-      displayWarning('Saving...')
+      // Request the course to be added.
+      // If moving a course, the warning will be updated by the remove request.
+      if (!oldCourseItem) displayWarning('Saving...')
       $.ajax({
         type: 'GET',
         url: '/1/planner/course/' + id + '/add/' + String(year),
         dataType: 'json',
         success: function(response) {
           if (response.success) {
-            // Remove the course from its old term if necessary
-            if (oldCourseItem) oldCourseItem.find('button').click()
-            else displayWarning('')
+            if (!oldCourseItem) displayWarning('')
           }
-          else {
-            displayWarning(response.message)
-            courseItem.remove()
-            addUnits(courseList, -units)
-          }
+          else displayWarning(response.message)
         },
         error: function() {
           displayWarning('Failed to add course ' + course.number)
-          courseItem.remove()
-          addUnits(courseList, -units)
         }
       })
     }
@@ -403,7 +400,9 @@
         dataType: 'json',
         success: function(response) {
           if (response.success) {
-            // Remove the previous location of this placeholder
+            // Remove the previous location of this placeholder.
+            // We can't add the placeholder until the response is received,
+            // since we wouldn't know its ID yet.
             if (placeholder) placeholder.remove()
             if (oldCourseItem) oldCourseItem.find('button').click()
             else displayWarning('')

--- a/tests/modules/courses/test_courses.py
+++ b/tests/modules/courses/test_courses.py
@@ -168,7 +168,7 @@ def test_planner_mine(client):
     # Test when not logged in
     rv = client.get(flask.url_for('courses.planner_mine'))
     assert rv.status_code == 200
-    assert json.loads(rv.data) == []
+    assert json.loads(rv.data) == {'courses': [], 'placeholders': []}
     rv = client.get(
         flask.url_for('courses.planner_add_course', course_id=1, year=2))
     assert rv.status_code == 200


### PR DESCRIPTION
### Summary
Fixes #190, so the planner can be used (without persistent storage) when not logged in. This entails a couple of changes:
- Don't remove added courses if the request to save them fails. We still display a prominent warning message.
- Don't wait for a successful request to remove courses
- Fix the `planner_mine` endpoint to return the correct response format (now that we have placeholders) when not logged in

Placeholders still won't work when not logged in, since we currently store their unique IDs in their HTML attributes. This could probably be changed, but it seems like a less common use case.

### Test Plan
Tested all the operations on the planner when logged in and when not logged in.