### PR TITLE
Remove whitespace from Jinja2 templates

### DIFF
--- a/donut/__init__.py
+++ b/donut/__init__.py
@@ -75,6 +75,8 @@ def init(environment_name):
     # Update jinja global functions
     app.jinja_env.globals.update(
         current_year=lambda: datetime.datetime.now().year)
+    app.jinja_env.trim_blocks = True
+    app.jinja_env.lstrip_blocks = True
 
     if environment_name == "prod":
         mail_handler = DonutSMTPHandler(


### PR DESCRIPTION
### Summary
Fixes #192. This eliminates a lot of extra whitespace around blocks in HTML generated from Jinja2 templates (e.g. `{% if ... %}`, `{% for ... %}`). As an example, the directory homepage goes from 332 lines to 227 and from 11398 to 10814 characters. I think this improves readability of the generated HTML (which is useful for debugging) and would reduce the server traffic somewhat.

### Test Plan
I visited most of the Donut pages and they seem to render fine. I haven't exhaustively verified functionality.