### PR TITLE
Embed airport carpools spreadsheet 

### DIFF
--- a/donut/__init__.py
+++ b/donut/__init__.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     from donut import default_config as config
 from donut import constants
-from donut.modules import account, auth, marketplace, calendar, core, courses, directory_search, editor, feedback, groups, newsgroups, rooms, uploads, voting
+from donut.modules import account, auth, marketplace, calendar, core, courses, directory_search, editor, feedback, groups, newsgroups, rooms, uploads, voting, flights
 from donut.donut_SMTP_handler import DonutSMTPHandler
 from donut.email_utils import DOMAIN
 
@@ -35,6 +35,7 @@ app.register_blueprint(rooms.blueprint)
 app.register_blueprint(uploads.blueprint)
 app.register_blueprint(voting.blueprint)
 app.register_blueprint(newsgroups.blueprint)
+app.register_blueprint(flights.blueprint)
 
 
 def init(environment_name):

--- a/donut/modules/flights/__init__.py
+++ b/donut/modules/flights/__init__.py
@@ -1,0 +1,4 @@
+import flask
+blueprint = flask.Blueprint('flights', __name__, template_folder='templates')
+
+from . import routes

--- a/donut/modules/flights/helpers.py
+++ b/donut/modules/flights/helpers.py
@@ -1,0 +1,41 @@
+import flask
+import pymysql.cursors
+from donut import auth_utils
+from donut.modules.groups import helpers as groups
+
+
+def update(link, visible):
+    """
+    Update the link and visible settings of the sheet.
+    """
+    query = """
+    DELETE FROM flights;
+    INSERT INTO flights (link, visible) 
+    VALUES (%s, %s) 
+    """
+    with flask.g.pymysql_db.cursor() as cursor:
+        cursor.execute(query, [link, visible])
+
+
+def get_settings():
+    """
+    Gets whether the sheet is visible and link.
+    If no sheet has been uploaded, returns not visible and empty link.
+    """
+    query = 'SELECT visible, link FROM flights'
+    with flask.g.pymysql_db.cursor() as cursor:
+        cursor.execute(query)
+        if not cursor.rowcount:
+            return {'visible': False, 'link': ''}
+        return cursor.fetchone()
+
+
+def is_admin():
+    """
+    Checks if user can control the settings.
+    """
+    if 'username' not in flask.session:
+        return False
+    user_id = auth_utils.get_user_id(flask.session['username'])
+    ascit_id = groups.get_group_id('ASCIT')
+    return auth_utils.is_admin() or groups.is_user_in_group(user_id, ascit_id)

--- a/donut/modules/flights/routes.py
+++ b/donut/modules/flights/routes.py
@@ -1,0 +1,35 @@
+import flask
+from donut import auth_utils
+
+from . import blueprint, helpers
+
+
+@blueprint.route('/flights')
+def flights():
+    if not auth_utils.check_login():
+        return flask.abort(403)
+    settings = helpers.get_settings()
+    return flask.render_template(
+        'flights.html',
+        visible=settings['visible'],
+        link=settings['link'],
+        admin=helpers.is_admin())
+
+
+@blueprint.route('/flights/update', methods=['POST'])
+def update():
+    if not helpers.is_admin():
+        return flask.abort(403)
+    link = flask.request.form.get('link')
+    visible = 'visible' in flask.request.form
+    helpers.update(link, visible)
+    return flask.redirect(flask.url_for('flights.settings'))
+
+
+@blueprint.route('/flights/settings')
+def settings():
+    if not helpers.is_admin():
+        return flask.abort(403)
+    settings = helpers.get_settings()
+    return flask.render_template(
+        'settings.html', visible=settings['visible'], link=settings['link'])

--- a/donut/modules/flights/templates/flights.html
+++ b/donut/modules/flights/templates/flights.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+{% block page %}
+
+<div class="container theme-showcase" role="main">
+	<div class="jumbotron">
+		<h1>Airport Carpools</h1>
+		{% if admin %}                        
+			<a class="btn btn-primary" href="{{ url_for('flights.settings') }}" role="button">Settings</a>
+		{% endif %}
+		{% if visible %}
+			<a class="btn btn-primary" href="{{ link }}" target="_blank">Go to Spreadsheet</a>
+			<iframe width=100% height=700 src="{{ link }}&rm=minimal"></iframe>
+		{% else %}
+			<h2>✈ Check back later ✈</h2>
+		{% endif %}
+	</div>
+</div>
+
+{% endblock %}

--- a/donut/modules/flights/templates/settings.html
+++ b/donut/modules/flights/templates/settings.html
@@ -1,0 +1,28 @@
+{% extends "layout.html" %}
+{% block page %}
+<div class="container theme-showcase" role="main">
+<div class="jumbotron">
+	<div class="col-sm-1">
+		    <a href="{{url_for('flights.flights')}}" class = "btn btn-primary back"> &lt;</a>
+	</div>
+	<div class="col-md-4">
+		<h2>Airport Carpool Settings</h2>
+		<form method="POST" action="{{ url_for('flights.update') }}">
+			<div class='form-group'>
+                		<label for="visible">Sheets are visible</label>
+				<input type="checkbox" id="visible" name="visible" {% if visible %} checked {% endif %}>
+			</div>
+			<div class='form-group'>
+				<label for="link">Google Sheet link:</label>
+				<ol>
+					<li> File → Publish to the Web → Embed (ignore this link!)</li>
+					<li> File → Share → Copy link </li>
+				</ol>
+				<input id="link" name="link" class="form-control" value="{{ link }}" />
+			</div>
+			<input class="btn btn-primary" type="submit" value="Update" />
+		</form>
+  	</div>
+	</div>
+</div>
+{% endblock %}

--- a/donut/templates/includes/header.html
+++ b/donut/templates/includes/header.html
@@ -26,6 +26,7 @@
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">User Services <span class="caret"></span></a>
                         <ul class="dropdown-menu" role="menu">
+			    <li><a href="{{ url_for('flights.flights') }}">Airport Carpools</a></li>
                             <li><a href="{{ url_for('feedback.feedback', group='arc') }}">ARC Feedback</a></li>
                             <li><a href="{{ url_for('calendar.calendar') }}">Calendar</a></li>
                             <li><a href="{{ url_for('courses.planner') }}">Course Planner</a></li>

--- a/sql/flights.sql
+++ b/sql/flights.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS flights;
+
+CREATE TABLE flights (
+    link	TEXT NOT NULL DEFAULT '',
+    visible     BOOLEAN NOT NULL DEFAULT FALSE
+);

--- a/sql/reset.sql
+++ b/sql/reset.sql
@@ -20,6 +20,7 @@ SOURCE sql/rooms.sql
 SOURCE sql/permissions.sql
 SOURCE sql/voting.sql
 SOURCE sql/courses.sql
+SOURCE sql/flights.sql
 
 SET FOREIGN_KEY_CHECKS = 1;
 

--- a/tests/modules/flights/test_flights.py
+++ b/tests/modules/flights/test_flights.py
@@ -1,0 +1,10 @@
+import flask
+from donut.modules.flights import helpers
+from donut.testing.fixtures import client
+
+
+def test_update(client):
+    helpers.update('', False)
+    assert helpers.get_settings() == {'visible': False, 'link': ''}
+    helpers.update('valid_link', True)
+    assert helpers.get_settings() == {'visible': True, 'link': 'valid_link'}


### PR DESCRIPTION
### Summary
- Add carpool spreadsheet page so that don't have to circulate it through email every break 
- ASCIT members and admins can update the link to the spreadsheet and hide the spreadsheet when it's not break season
- Users can edit the spreadsheet directly on Donut or open it in Google Sheets 

### Test Plan
- Tried on local host
