### PR TITLE
Remove members_can_send field in groups

### DIFF
--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -19,7 +19,7 @@ def get_group_list_data(fields=None, attrs={}):
     """
     all_returnable_fields = [
         "group_id", "group_name", "group_desc", "type", "anyone_can_send",
-        "members_can_send", "newsgroups", "visible", "admin_control_members"
+        "newsgroups", "visible", "admin_control_members"
     ]
     default_fields = ["group_id", "group_name", "group_desc", "type"]
     if fields == None:
@@ -123,7 +123,7 @@ def get_group_data(group_id, fields=None):
     """
     all_returnable_fields = [
         "group_id", "group_name", "group_desc", "type", "anyone_can_send",
-        "members_can_send", "newsgroups", "visible", "admin_control_members"
+        "newsgroups", "visible", "admin_control_members"
     ]
     default_fields = ["group_id", "group_name", "group_desc", "type"]
     if fields is None:
@@ -253,7 +253,6 @@ def create_group(group_name,
                  group_type="",
                  newsgroups=False,
                  anyone_can_send=False,
-                 members_can_send=False,
                  visible=False,
                  admin_control_members=True):
     """
@@ -265,17 +264,16 @@ def create_group(group_name,
         group_type: Type of group
         newgroups: Toggles if group is a news group
         anyone_can_send: Toggles if anyone can send emails to this group
-        memberse_can_send: Toggles if members can send emails to this group
         visible: Toggles if the group is visible
         admin_control_members: toggles if administrator can control membership
     """
     query = """INSERT INTO groups (group_name, group_desc, type,
-        newsgroups, anyone_can_send, members_can_send, visible,
-        admin_control_members) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)"""
+        newsgroups, anyone_can_send, visible,
+        admin_control_members) VALUES (%s, %s, %s, %s, %s, %s, %s)"""
     with flask.g.pymysql_db.cursor() as cursor:
-        cursor.execute(query, (group_name, group_desc, group_type, newsgroups,
-                               anyone_can_send, members_can_send, visible,
-                               admin_control_members))
+        cursor.execute(query,
+                       (group_name, group_desc, group_type, newsgroups,
+                        anyone_can_send, visible, admin_control_members))
         new_group_id = cursor.lastrowid
     add_position(new_group_id, "Member")
     return new_group_id

--- a/donut/modules/newsgroups/routes.py
+++ b/donut/modules/newsgroups/routes.py
@@ -82,8 +82,8 @@ def view_group(group_id):
     user_id = auth_utils.get_user_id(flask.session['username'])
     actions = helpers.get_user_actions(user_id, group_id)
     fields = [
-        'group_id', 'group_name', 'group_desc', 'anyone_can_send',
-        'members_can_send', 'visible', 'admin_control_members'
+        'group_id', 'group_name', 'group_desc', 'anyone_can_send', 'visible',
+        'admin_control_members'
     ]
     group_info = groups.get_group_data(group_id, fields)
     applications = None

--- a/sql/donut.sql
+++ b/sql/donut.sql
@@ -113,9 +113,6 @@ CREATE TABLE groups (
                                                         -- whether or not
                                                         -- anyone can send
                                                         -- emails to the group
-    members_can_send        BOOLEAN      DEFAULT FALSE, -- Controls if any
-                                                        -- member can send to
-                                                        -- the group
     visible                 BOOLEAN      DEFAULT FALSE, -- Controls if anyone
                                                         -- anyone can see this
                                                         -- group

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -212,17 +212,16 @@ def test_create_pos_holders(client):
 
 def test_create_group(client):
     group_id = helpers.create_group("Page House", "May the work be light",
-                                    "House", False, False, True, True, True)
+                                    "House", False, False, True, True)
     assert helpers.get_group_data(group_id, [
         "group_id", "group_name", "group_desc", "type", "anyone_can_send",
-        "members_can_send", "newsgroups", "visible", "admin_control_members"
+        "newsgroups", "visible", "admin_control_members"
     ]) == {
         "group_name": "Page House",
         "group_desc": "May the work be light",
         "type": "House",
         "newsgroups": False,
         "anyone_can_send": False,
-        "members_can_send": True,
         "visible": True,
         "admin_control_members": True,
         "group_id": group_id


### PR DESCRIPTION
### Summary
- `members_can_send` is not used anywhere
- Whether a user can send to a group is controlled by `send` field in `positions` table
- will remove from MariaDB after

### Test Plan
- Unit tests
