### PR TITLE
Allow admin access to any group

### DIFF
--- a/donut/modules/newsgroups/routes.py
+++ b/donut/modules/newsgroups/routes.py
@@ -90,7 +90,8 @@ def view_group(group_id):
     if actions['control']:
         applications = helpers.get_applications(group_id)
     messages = None
-    member = groups.is_user_in_group(user_id, group_id)
+    member = auth_utils.is_admin() or groups.is_user_in_group(
+        user_id, group_id)
     if member:
         messages = helpers.get_past_messages(group_id)
     return flask.render_template(

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -5,9 +5,9 @@ INSERT INTO options(option_id, option_name) VALUES
     (1, 'CS'),
     (2, 'MechE');
 
-INSERT INTO members(uid, last_name, first_name, email, phone) VALUES
-    ('1957540', 'Qu', 'David', 'davidqu12345@gmail.com', NULL),
-    ('1984853', 'Eng', 'Robert', 'reng@caltech.edu', '+11234567890');
+INSERT INTO members(user_id, uid, last_name, first_name, email, phone) VALUES
+    (1, '1957540', 'Qu', 'David', 'davidqu12345@gmail.com', NULL),
+    (2, '1984853', 'Eng', 'Robert', 'reng@caltech.edu', '+11234567890');
 INSERT INTO members(
     user_id,
     uid,
@@ -47,9 +47,9 @@ INSERT INTO members(
     1,
     '203'
 );
-INSERT INTO members(uid, last_name, first_name, email) VALUES
-    ('2045251', 'Yu', 'Sean', 'ssyu@caltech.edu'),
-    ('2077933', 'Lin', 'Rachel', 'rlin@caltech.edu');
+INSERT INTO members(user_id, uid, last_name, first_name, email) VALUES
+    (4, '2045251', 'Yu', 'Sean', 'ssyu@caltech.edu'),
+    (5, '2077933', 'Lin', 'Rachel', 'rlin@caltech.edu');
 
 INSERT INTO member_options(user_id, option_id, option_type) VALUES
     (3, 1, 'Major'),


### PR DESCRIPTION
### Summary
- Remove all rows in `position_relations` where `pos_id_from=pos_id` for devteam member
- Check `is_admin` instead since devteam member should have access to any position
- Allow devteam member to post as devteam member to any group

### Test Plan
- Unit tests and tested with fake `test_newsgroup`
