### PR TITLE
limit length of feedback name and subject

### DIFF
--- a/donut/modules/feedback/templates/complaint.html
+++ b/donut/modules/feedback/templates/complaint.html
@@ -87,7 +87,7 @@
                         <form method="POST" id="addMessage" action="{{ url_for('feedback.feedback_add_msg', id=complaint['uuid'], group=group) }}">
                             <div class="form-group">
                                 <p>Name: </p>
-                                <input class="form-control" type="text" name="poster" />
+                                <input class="form-control" name="poster" maxlength="50"/>
                             </div>
                             <div class="form-group">
                                 <p>Message: </p>

--- a/donut/modules/feedback/templates/feedback.html
+++ b/donut/modules/feedback/templates/feedback.html
@@ -26,7 +26,7 @@
                     <label for="name">Name:</label>
                   </td>
                   <td>
-                    <input id="name" name="name" class="form-control" />
+                    <input id="name" name="name" class="form-control" maxlength="50"/>
                   </td>
                 </tr>
                 <tr>
@@ -42,7 +42,7 @@
 			    <label class="required" for="subject">Subject{% if group == 'arc' %} (or Course){% endif %}:</label>
                     </td>
                     <td>
-                      <input id="subject" name="subject" class="form-control" required />
+                      <input id="subject" name="subject" class="form-control" maxlength="50" required />
                     </td>
                 </tr>
 		{% if group == 'arc' %}

--- a/sql/feedback.sql
+++ b/sql/feedback.sql
@@ -25,7 +25,7 @@ CREATE TABLE complaint_messages (
 
 CREATE TABLE complaint_emails (
   complaint_id INT(11) NOT NULL,
-  email VARCHAR(50) NOT NULL,
+  email VARCHAR(255) NOT NULL,
   PRIMARY KEY (complaint_id, email),
   FOREIGN KEY (complaint_id) REFERENCES complaint_info (complaint_id) ON DELETE CASCADE
 ); 


### PR DESCRIPTION
### Summary
- Limit name and subject text box to 50 chars to match SQL column types 
- Increase length limit for email to max length possible for email

### Test Plan
- Tested posting feedback
