### PR TITLE
More scheduler notes features

### DIFF
--- a/donut/modules/courses/routes.py
+++ b/donut/modules/courses/routes.py
@@ -188,15 +188,21 @@ def edit_notes():
             'success': False,
             'message': 'Must be logged in to save'
         })
-    helpers.edit_notes(username,
-                       flask.request.form.get('courseId'),
-                       flask.request.form.get('notes'))
+
+    data = flask.request.get_json(force=True)
+    course = data.get('course')
+    section = data.get('section')
+    notes = data.get('notes')
+    if notes:
+        helpers.edit_notes(username, course, section, notes)
+    else:
+        helpers.delete_notes(username, course, section)
     return flask.jsonify({'success': True})
 
 
-@blueprint.route('/1/scheduler/notes/<int:course>')
-def get_notes(course):
+@blueprint.route('/1/scheduler/notes/<int:course>/section/<int:section>')
+def get_notes(course, section):
     username = flask.session.get('username')
-    if not username: return flask.jsonify('')
+    if not username: return flask.jsonify(None)
 
-    return flask.jsonify(helpers.get_notes(username, course) or '')
+    return flask.jsonify(helpers.get_notes(username, course, section))

--- a/donut/modules/courses/templates/notes_modal.html
+++ b/donut/modules/courses/templates/notes_modal.html
@@ -1,22 +1,28 @@
-<div class="modal fade" id="modal" tabindex="-1" role="dialog" aria-hidden="true">
+<div
+	class="modal fade"
+	id="modal"
+	tabindex="-1"
+	role="dialog"
+	aria-hidden="true"
+	data-backdrop="static"
+	data-keyboard="false"
+>
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+				<button class="close" id="close-notes">
 					<span aria-hidden="true">&times;</span>
 				</button>
-				<h5 class="modal-title" id="modalTitle"></h5>
+				<h5 id="modal-title"></h5>
 			</div>
 			<div class="modal-body">
-				<div id="viewNotes"></div>
-				<form id='postNotes'>
-					<input type="hidden" id="courseId" name="courseId">
-					<input type="hidden" id="courseNum" name="courseNum">
-					<textarea class="form-control" id="notes" name="notes" rows="10"></textarea>
-					<input class="btn btn-primary" type="submit" value="Save" />
-				</form>
-				<div class="modal-footer">
-					<button class="btn btn-primary ml-auto" id="editButton">Edit</button>
+				<div id="old-notes">
+					<div id="notes-display"></div>
+					<button class="btn btn-primary" id="edit-notes">Edit</button>
+				</div>
+				<div id="new-notes">
+					<textarea class="form-control" id="notes-input" rows="10"></textarea>
+					<button class="btn btn-primary" id="save-notes">Save</button>
 				</div>
 			</div>
 		</div>

--- a/donut/modules/courses/templates/scheduler.html
+++ b/donut/modules/courses/templates/scheduler.html
@@ -264,6 +264,12 @@
                 $('<strong>').text(course.number),
                 $('<div>').text(sectionNumber)
               ),
+              // edit button
+              $('<button>')
+                .attr('type', 'button')
+                .addClass('btn edit')
+                .append($('<span>').addClass('glyphicon glyphicon-edit'))
+                .click(function() { displayNotes(course, sectionNumber) }),
               // delete button
               $('<button>')
                 .attr({
@@ -280,13 +286,7 @@
                   fitIntervals()
                   dropSection(course, sectionNumber)
                   e.stopPropagation() // prevent section dropdowns from closing
-                }),
-              // edit button
-              $('<button>')
-                .attr('type', 'button')
-                .addClass('btn edit')
-                .append($('<span>').addClass('glyphicon glyphicon-edit'))
-                .click(function() { displayNotes(course, sectionNumber) })
+                })
             )
           dayLists.eq(weekday).append(intervalItem)
           intervals.push(intervalItem)

--- a/donut/modules/courses/templates/scheduler.html
+++ b/donut/modules/courses/templates/scheduler.html
@@ -283,17 +283,10 @@
                 }),
               // edit button
               $('<button>')
-                .attr({
-                  type: 'button',
-                  course: course.id,
-                  section: sectionNumber,
-                  class: 'btn edit',
-                  "data-toggle": 'modal',
-                  "data-target": '#modal',
-                  "data-course-id": course.id,
-                  "data-course-num": course.number
-                })
+                .attr('type', 'button')
+                .addClass('btn edit')
                 .append($('<span>').addClass('glyphicon glyphicon-edit'))
+                .click(function() { displayNotes(course, sectionNumber) })
             )
           dayLists.eq(weekday).append(intervalItem)
           intervals.push(intervalItem)
@@ -496,55 +489,31 @@
     function displayUnits() {
       units.text('Units: ' + String(coursesUnits))
     }
-    $('#modal').on('show.bs.modal', function(e) {
-      var courseNum = $(e.relatedTarget).data("courseNum");
-      var courseId = $(e.relatedTarget).data("courseId");
-      displayNotes(courseNum, courseId);
-    });
-    $('#editButton').click(function() {
-      $('#notes').val($('#notes').text());
-      $('#postNotes').show();
-      $('#viewNotes').hide();
-      $('#editButton').hide();
-    });
-    $('#postNotes').submit(function(e) {
-      e.preventDefault();
-      $.ajax({
-        url: '/1/scheduler/edit_notes',
-        type: 'POST',
-        data:$('#postNotes').serialize(),
-        success: function(data) {
-          if (data.success) {
-            displayNotes($('#courseNum').val(), $('#courseId').val());
-            displayWarning('');
-          }
-          else displayWarning('Failed to save notes: ' + data.message);
-        },
-        error: function() {
-          displayWarning('Failed to save notes')
-        }
-      });
-    });
-    function displayNotes(courseNum, courseId) {
-      $('#courseId').val(courseId);
-      $('#courseNum').val(courseNum);
-      $('#modalTitle').text(courseNum);
+
+    var notesCourse, notesSection
+    function displayNotes(course, sectionNumber) {
+      notesCourse = course.id
+      notesSection = sectionNumber
+      $('#modal-title').text(course.number)
+      $('#modal').modal('show')
+      $('#notes-display').text('Loading...')
+      $('#old-notes').show()
+      $('#new-notes').hide()
       $.ajax({
         type: 'GET',
-        url: '/1/scheduler/notes/' + courseId,
+        url: '/1/scheduler/notes/' + String(course.id) + '/section/' + String(sectionNumber),
         success: function(notes) {
-          $('#viewNotes').html(formatText(notes, 'p', '_blank'));
-          $('#viewNotes').show();
-          $('#editButton').show();
-          $('#postNotes').hide();
-          $('#notes').text(notes);
-          displayWarning('');
+          if (notes === null) notes = ''
+          $('#notes-display').html(formatText(notes, 'p', '_blank'))
+          $('#notes-input').val(notes)
+          displayWarning('')
         },
         error: function() {
           displayWarning('Failed to load notes')
         }
       })
     }
+
     $(document).ready(function() {
       termSelect = $('#term').change(loadTerm)
       coursesList = $('#courses')
@@ -553,6 +522,41 @@
       })
       dayLists = $('.day')
       units = $('#units')
+
+      $('#edit-notes').click(function() {
+        $('#old-notes').hide()
+        $('#new-notes').show()
+        $('#notes-input').focus()
+      })
+      $('#save-notes').click(function() {
+        var notes = $('#notes-input').val()
+        $.ajax({
+          url: '/1/scheduler/edit_notes',
+          type: 'POST',
+          data: JSON.stringify({
+            course: notesCourse,
+            section: notesSection,
+            notes: notes
+          }),
+          success: function(data) {
+            if (data.success) {
+              $('#notes-display').html(formatText(notes, 'p', '_blank'))
+              $('#new-notes').hide()
+              $('#old-notes').show()
+              displayWarning('')
+            }
+            else displayWarning('Failed to save notes: ' + data.message)
+          },
+          error: function() {
+            displayWarning('Failed to save notes')
+          }
+        })
+      })
+      $('#close-notes').click(function() {
+        if ($('#new-notes').is(':hidden') || confirm('Discard changes to notes?')) {
+          $('#modal').modal('hide')
+        }
+      })
 
       loadTerm()
     })

--- a/sql/courses.sql
+++ b/sql/courses.sql
@@ -74,18 +74,10 @@ CREATE TABLE scheduler_sections (
     user_id         INT      NOT NULL,
     course_id       INT      NOT NULL,
     section_number  TINYINT  NOT NULL,
+    notes           TEXT,
     PRIMARY KEY (user_id, course_id, section_number),
     FOREIGN KEY (user_id) REFERENCES members(user_id),
     FOREIGN KEY (course_id, section_number)
         REFERENCES sections(course_id, section_number)
         ON DELETE CASCADE
 );
-
-CREATE TABLE scheduler_notes (
-    user_id         INT      NOT NULL,
-    course_id       INT      NOT NULL,
-    notes	    TEXT     NOT NULL,
-    PRIMARY KEY (user_id, course_id),
-    FOREIGN KEY (user_id) REFERENCES members(user_id) ON DELETE CASCADE,
-    FOREIGN KEY (course_id) REFERENCES courses(course_id) ON DELETE CASCADE
-)


### PR DESCRIPTION
### Summary
- Moves course notes into the `scheduler_sections` table. This saves on storage, makes notes per-section instead of per-course, and means they are automatically removed when a section is dropped.
- Warns before closing the notes modal if editing is in progress
- Shows a loading message when fetching notes
- Show delete button instead of notes button when space is limited

### Test Plan
Tested all the UI actions manually

Note to self: need to do the following in prod
- `ALTER TABLE scheduler_sections ADD COLUMN notes TEXT;`
- `UPDATE scheduler_sections SET notes = (SELECT notes FROM scheduler_notes WHERE user_id = scheduler_sections.user_id AND course_id = scheduler_sections.course_id);`
- Pull these changes
- `DROP TABLE scheduler_notes;`
