### PR TITLE
Make core progress more accurate

### DIFF
--- a/donut/modules/courses/templates/planner.html
+++ b/donut/modules/courses/templates/planner.html
@@ -90,15 +90,47 @@
         <div class='progress-bar progress-bar-success' id='ch3'></div>
       </div>
 
-      Additional intro lab
+      Additional introductory lab
       <div class='progress'>
         <div class='progress-bar progress-bar-success' id='add-lab'></div>
       </div>
 
-      Humanities
+      Humanities and social sciences
       <div class='progress'>
-        <div class='progress-bar progress-bar-success' id='hums'></div>
+        <div class='progress-bar progress-bar-success' id='hss'></div>
       </div>
+      <ul id='hss-categories'>
+        <li>
+          Freshman humanities
+          <div class='progress'>
+            <div class='progress-bar progress-bar-success' id='frosh-hums'></div>
+          </div>
+        </li>
+        <li>
+          Advanced humanities
+          <div class='progress'>
+            <div class='progress-bar progress-bar-success' id='hums'></div>
+          </div>
+        </li>
+        <li>
+          Introductory social sciences
+          <div class='progress'>
+            <div class='progress-bar progress-bar-success' id='intro-ss'></div>
+          </div>
+        </li>
+        <li>
+          Advanced social sciences
+          <div class='progress'>
+            <div class='progress-bar progress-bar-success' id='ss'></div>
+          </div>
+        </li>
+        <li>
+          Writing intensives
+          <div class='progress'>
+            <div class='progress-bar progress-bar-success' id='writing'></div>
+          </div>
+        </li>
+      </ul>
 
       PE
       <div class='progress'>
@@ -193,6 +225,10 @@
       margin-top: 5px;
       margin-bottom: 5px;
     }
+    #hss-categories {
+      font-size: 14px;
+      font-weight: 400;
+    }
     #close-requirements {
       position: absolute;
       right: 5px;
@@ -213,6 +249,7 @@
   <script src='{{ url_for("static", filename="js/courses/search.js") }}'></script>
   <script>
     var SHOW_COURSES = 50
+    var NUMBER_MATCH = /^\d+/
     var HUMANITIES_DEPARTMENTS = {
       En: true,
       H: true,
@@ -234,6 +271,27 @@
     var MISC_HSS_DEPARTMENTS = {
       L: true,
       Wr: true
+    }
+    var INTRO_SS_COURSES = {
+      'An 14': true,
+      'An 15': true,
+      'An 16': true,
+      'Ec 11': true,
+      'PS 12': true,
+      'Psy 13': true
+    }
+    var WRITING_INTENSIVE_SS_COURSES = {
+      'An/PS 127': true,
+      'Ec 105': true,
+      'Ec 129': true,
+      'Ec 130': true,
+      'Ec 140': true,
+      'PS 99a': true,
+      'PS 99b': true,
+      'PS 120': true,
+      'PS 123': true,
+      'PS 141a': true,
+      'PS 141b': true
     }
 
     var courses = []
@@ -508,11 +566,12 @@
           Ma1a = false, Ma1b = false, Ma1c = false,
           Ph1a = false, Ph1b = false, Ph1c = false,
           Ch1a = false, Ch1b = false,
-          Bi1 = false,
+          Bi1 = false, Bi1x = false, Bi8 = false, Bi9 = false,
           menu = false,
-          Ch3 = false, labUnits = 0,
+          Ch3 = false, Ch3AltUnits = 0, labUnits = 0,
           PE = 0,
-          humanities = 0, socialSciences = 0, hss = 0
+          hss = 0, froshHumDepartments = {}, humanities = 0,
+          introSS = 0, socialSciences = 0, writingIntensive = 0
       termLists.each(function() {
         $(this).children('.course').each(function() {
           var $this = $(this)
@@ -528,11 +587,10 @@
             case 'Ph 1c': Ph1c = true; break
             case 'Ch 1a': Ch1a = true; break
             case 'Ch 1b': Ch1b = true; break
-            case 'Bi 1':
-            case 'Bi 1x':
-            case 'Bi 8':
-            case 'Bi 9':
-              Bi1 = true; break
+            case 'Bi 1': Bi1 = true; break
+            case 'Bi 1x': Bi1x = true; break
+            case 'Bi 8': Bi8 = true; break
+            case 'Bi 9': Bi9 = true; break
             case 'Ay 1':
             case 'EE 1':
             case 'ESE 1':
@@ -542,14 +600,15 @@
             case 'Ch 3a':
             case 'Ch 3x':
               Ch3 = true; break
-            case 'APh/EE 9a':
-            case 'APh/EE 9b':
-            case 'APh 24':
-            case 'Bi 10':
             case 'Ch 4a':
-            case 'Ch 4b':
             case 'Ch 8':
             case 'Ch/ChE 9':
+              Ch3AltUnits += units; break
+            case 'APh/EE 9a':
+            case 'APh/EE 9b':
+            case 'APh/EE 24':
+            case 'Bi 10':
+            case 'Ch 4b':
             case 'EE/ME 7':
             case 'Ge 116':
             case 'Ph 3':
@@ -558,17 +617,33 @@
             case 'Ph 8c':
               labUnits += units; break
             default:
-              if (courseName.startsWith('PE ')) PE++
+              var courseNamePieces = courseName.split(' ')
+              var departmentString = courseNamePieces[0], number = courseNamePieces[1]
+              if (departmentString === 'PE') PE++
               else if (units >= 9) {
-                var departments = courseName.split(' ')[0].split('/')
+                number = Number(NUMBER_MATCH.exec(number)[0])
+                var departments = departmentString.split('/')
                 var isHumanity = departments.some(function(department) {
                   return department in HUMANITIES_DEPARTMENTS
                 })
-                if (isHumanity) humanities++
-                var isSocialScience = departments.some(function(department) {
-                  return department in SOCIAL_SCIENCE_DEPARTMENTS
-                })
-                if (isSocialScience) socialSciences++
+                if (isHumanity) {
+                  if (number <= 50) froshHumDepartments[departmentString] = true
+                  else if (number >= 90) {
+                    humanities++
+                    writingIntensive++
+                  }
+                }
+                var isSocialScience = courseName !== 'BEM 102' &&
+                  departments.some(function(department) {
+                    return department in SOCIAL_SCIENCE_DEPARTMENTS
+                  })
+                if (isSocialScience) {
+                  if (courseName in INTRO_SS_COURSES) introSS++
+                  else {
+                    if (number >= 100) socialSciences++
+                    if (courseName in WRITING_INTENSIVE_SS_COURSES) writingIntensive++
+                  }
+                }
                 var isHSS = isHumanity || isSocialScience ||
                   departments.some(function(department) {
                     return department in MISC_HSS_DEPARTMENTS
@@ -578,6 +653,16 @@
           }
         })
       })
+      Bi1 = Bi1 || (Bi8 && Bi9);
+      if (Bi1x) {
+        if (Bi1) labUnits += 9;
+        else Bi1 = true;
+      }
+      if (!Ch3 && Ch3AltUnits) {
+        Ch3 = true;
+        Ch3AltUnits -= 9;
+      }
+      labUnits += Ch3AltUnits;
       $('.progress-bar#units').text(totalUnits).css('width', totalUnits / 486 * 100 + '%')
       $('.progress-bar#ma1').css('width', (Ma1a + Ma1b + Ma1c) / 3 * 100 + '%')
       $('.progress-bar#ph1').css('width', (Ph1a + Ph1b + Ph1c) / 3 * 100 + '%')
@@ -586,9 +671,13 @@
       $('.progress-bar#menu').css('width', menu * 100 + '%')
       $('.progress-bar#ch3').css('width', Ch3 * 100 + '%')
       $('.progress-bar#add-lab').css('width', Math.min(labUnits / 6, 1) * 100 + '%')
-      $('.progress-bar#hums')
-        .text('Humanities: ' + String(humanities) + '; Social sciences: ' + String(socialSciences))
-        .css('width', Math.min(hss / 12, 1) * 100 + '%')
+      $('.progress-bar#hss').css('width', Math.min(hss / 12, 1) * 100 + '%')
+      $('.progress-bar#frosh-hums')
+        .css('width', Math.min(Object.keys(froshHumDepartments).length / 2, 1) * 100 + '%')
+      $('.progress-bar#hums').css('width', Math.min(humanities / 2, 1) * 100 + '%')
+      $('.progress-bar#intro-ss').css('width', Math.min(introSS / 2, 1) * 100 + '%')
+      $('.progress-bar#ss').css('width', Math.min(socialSciences / 2, 1) * 100 + '%')
+      $('.progress-bar#writing').css('width', Math.min(writingIntensive / 3, 1) * 100 + '%')
       $('.progress-bar#pe').css('width', Math.min(PE / 3, 1) * 100 + '%')
     }
     function setCoursesHeight() {


### PR DESCRIPTION
### Summary
Apparently this is a popular feature, so I updated the logic to match the Catalog more closely:
- Bi 8 and 9 must be taken together to satisfy the biology requirement
- Bi 1x can count as an additional lab if not used for the biology requirement
- Ch 3 requirement can be satisfied by Ch 4a, Ch 8, or Ch/ChE 9
- APh 24 is now APh/EE 24
- Show each piece of the humanities requirement: frosh and advanced hums, intro and advanced SS, and writing intensive classes

### Test Plan
Tried out all the cases for course combinations I could think of
