### PR TITLE
Remove unused groups.admin_control_members column

### DIFF
--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -19,7 +19,7 @@ def get_group_list_data(fields=None, attrs={}):
     """
     all_returnable_fields = [
         "group_id", "group_name", "group_desc", "type", "anyone_can_send",
-        "newsgroups", "visible", "admin_control_members"
+        "newsgroups", "visible"
     ]
     default_fields = ["group_id", "group_name", "group_desc", "type"]
     if fields == None:
@@ -123,7 +123,7 @@ def get_group_data(group_id, fields=None):
     """
     all_returnable_fields = [
         "group_id", "group_name", "group_desc", "type", "anyone_can_send",
-        "newsgroups", "visible", "admin_control_members"
+        "newsgroups", "visible"
     ]
     default_fields = ["group_id", "group_name", "group_desc", "type"]
     if fields is None:
@@ -253,8 +253,7 @@ def create_group(group_name,
                  group_type="",
                  newsgroups=False,
                  anyone_can_send=False,
-                 visible=False,
-                 admin_control_members=True):
+                 visible=False):
     """
     Creates a group with the given group_id, group name and other specifications
 
@@ -265,15 +264,15 @@ def create_group(group_name,
         newgroups: Toggles if group is a news group
         anyone_can_send: Toggles if anyone can send emails to this group
         visible: Toggles if the group is visible
-        admin_control_members: toggles if administrator can control membership
     """
-    query = """INSERT INTO groups (group_name, group_desc, type,
-        newsgroups, anyone_can_send, visible,
-        admin_control_members) VALUES (%s, %s, %s, %s, %s, %s, %s)"""
+    query = """
+        INSERT INTO groups (
+            group_name, group_desc, type, newsgroups, anyone_can_send, visible
+        ) VALUES (%s, %s, %s, %s, %s, %s)
+    """
     with flask.g.pymysql_db.cursor() as cursor:
-        cursor.execute(query,
-                       (group_name, group_desc, group_type, newsgroups,
-                        anyone_can_send, visible, admin_control_members))
+        cursor.execute(query, (group_name, group_desc, group_type, newsgroups,
+                               anyone_can_send, visible))
         new_group_id = cursor.lastrowid
     add_position(new_group_id, "Member")
     return new_group_id

--- a/donut/modules/newsgroups/routes.py
+++ b/donut/modules/newsgroups/routes.py
@@ -82,8 +82,7 @@ def view_group(group_id):
     user_id = auth_utils.get_user_id(flask.session['username'])
     actions = helpers.get_user_actions(user_id, group_id)
     fields = [
-        'group_id', 'group_name', 'group_desc', 'anyone_can_send', 'visible',
-        'admin_control_members'
+        'group_id', 'group_name', 'group_desc', 'anyone_can_send', 'visible'
     ]
     group_info = groups.get_group_data(group_id, fields)
     applications = None

--- a/donut/modules/newsgroups/templates/group.html
+++ b/donut/modules/newsgroups/templates/group.html
@@ -17,14 +17,11 @@
 				<ul style="list-style-type:disc;">
 					<li>
 						{% if group['anyone_can_send'] %}
-							Anyone can post to this group. 
+							Anyone can post to this group.
 						{% else %}
-							Posting is restricted to authorized members. 
+							Posting is restricted to authorized members.
 						{% endif %}
 					</li>
-					{% if group['admin_control_members'] %}
-						<li> Administrators control the membership of this group. </li>
-					{% endif %}
 					{% if group['visible'] %}
 						<li> Anyone can learn that this group exists. </li>
 					{% endif %}
@@ -72,13 +69,13 @@
 					<div class="panel panel-default">
 						<div class="panel-heading">
 							<h4 class="panel-title">
-								<a data-toggle="collapse" href="#owners">Group Owners</a> 
+								<a data-toggle="collapse" href="#owners">Group Owners</a>
 							</h4>
 						</div>
 						<div id="owners" class="panel-body collapse">
 							{% for pos_name, pos_people in owners.items() %}
 								<h5> {{ pos_name }}: </h5>
-								{% for person in pos_people %} 
+								{% for person in pos_people %}
 									<div>
 										<a href={{ url_for('directory_search.view_user', user_id=person.user_id) }}>{{ person.full_name }}</a>
 									</div>

--- a/sql/donut.sql
+++ b/sql/donut.sql
@@ -39,8 +39,7 @@ CREATE TABLE members (
     phone              VARCHAR(64)  DEFAULT NULL,
     gender             TINYINT      DEFAULT NULL, -- Numerical code that will be
                                                   -- stored in code
-    gender_custom      VARCHAR(32)  DEFAULT NULL, -- TODO: Implement showing
-                                                  -- custom gender options
+    gender_custom      VARCHAR(32)  DEFAULT NULL,
     birthday           DATE         DEFAULT NULL,
     entry_year         YEAR(4)      DEFAULT NULL,
     graduation_year    YEAR(4)      DEFAULT NULL,
@@ -118,9 +117,6 @@ CREATE TABLE groups (
     visible                 BOOLEAN      DEFAULT FALSE, -- Controls if anyone
                                                         -- anyone can see this
                                                         -- group
-    admin_control_members   BOOLEAN      DEFAULT TRUE,  -- Toggles whether or
-                                                        -- not admins control
-                                                        -- Group membership
     PRIMARY KEY (group_id),
     UNIQUE (group_name)
 );

--- a/tests/modules/groups/test_groups.py
+++ b/tests/modules/groups/test_groups.py
@@ -212,10 +212,10 @@ def test_create_pos_holders(client):
 
 def test_create_group(client):
     group_id = helpers.create_group("Page House", "May the work be light",
-                                    "House", False, False, True, True)
+                                    "House", False, False, True)
     assert helpers.get_group_data(group_id, [
         "group_id", "group_name", "group_desc", "type", "anyone_can_send",
-        "newsgroups", "visible", "admin_control_members"
+        "newsgroups", "visible"
     ]) == {
         "group_name": "Page House",
         "group_desc": "May the work be light",
@@ -223,7 +223,6 @@ def test_create_group(client):
         "newsgroups": False,
         "anyone_can_send": False,
         "visible": True,
-        "admin_control_members": True,
         "group_id": group_id
     }
 


### PR DESCRIPTION
### Summary
Not sure what the intention of this column was, but it's not currently used. We are just using `positions.control` to tell whether or not a position can control the members of a group. There's also no way currently to create a new group in the UI. All existing groups have this column set to `TRUE`. Also removes a SQL comment about custom genders not being implemented; this was done a while ago.

### Test Plan
`make test`
Newsgroup template, which was the only code using the value, renders successfully after dropping column in dev DB.

**Note to self: need to `ALTER TABLE groups DROP COLUMN admin_control_members;` in prod after pulling**
