### PR TITLE
Let admins control all groups

### DIFF
--- a/donut/modules/groups/helpers.py
+++ b/donut/modules/groups/helpers.py
@@ -1,5 +1,6 @@
 import flask
 import pymysql.cursors
+from donut.auth_utils import is_admin
 from donut.modules.core import helpers as core
 
 
@@ -78,8 +79,9 @@ def get_position_holders(pos_id):
 
     query = f"""
         SELECT DISTINCT user_id, full_name, hold_id, start_date, end_date
-        FROM current_position_holders NATURAL JOIN members_full_name
+        FROM current_position_holders NATURAL JOIN members NATURAL JOIN members_full_name
         WHERE pos_id IN ({', '.join('%s' for id in pos_id)})
+        ORDER BY last_name, full_name
     """
 
     with flask.g.pymysql_db.cursor() as cursor:
@@ -352,6 +354,9 @@ def can_control(user_id, group_id):
     """
     Returns whether the given user has control privileges for the given group.
     """
+    if is_admin():
+        return True
+
     query = """
         SELECT pos_id
         FROM current_position_holders NATURAL JOIN positions

--- a/donut/templates/campus_positions.html
+++ b/donut/templates/campus_positions.html
@@ -85,6 +85,16 @@
                 <div id="assignHold" class="tab-pane fade in">
                     <form id="holdForm">
                         <div class="form-group">
+                            <label class="required" for="groupIdHold">Group:</label>
+                            <select
+                                class="form-control"
+                                id="groupIdHold"
+                                onchange="populateAddPositions()"
+                            >
+                                <option>Pick a Group</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
                             <label class="required" for="posIdHold">Position:</label>
                             <select class="form-control" id="posIdHold">
                                 <option>Pick a Position</option>
@@ -113,8 +123,24 @@
                 <div id="removeHold" class="tab-pane fade in">
                     <form id="removeHoldForm">
                         <div class="form-group">
-                            <label class="required" for="posHold">Position Holder:</label>
-                            <select class="form-control" id="posHold">
+                            <label class="required" for="groupIdHolder">Group:</label>
+                            <select
+                                class="form-control"
+                                id="groupIdHolder"
+                                onchange="populateRemovePositions()"
+                            >
+                                <option>Pick a Group</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="required" for="posIdHolder">Position:</label>
+                            <select class="form-control" id="posIdHolder" onchange="populateHolders()">
+                                <option>Pick a Position</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="required" for="holdId">Position Holder:</label>
+                            <select class="form-control" id="holdId">
                                 <option>Pick a Position Holder</option>
                             </select>
                         </div>


### PR DESCRIPTION
### Summary
Fixes #222.
Supports more positions and position holders in the UI by requiring the user to select group, then position in that group, then holder of that position.
Position holders are also ordered by name to make them easier to find.

### Test Plan
Tested adding and removing positions from other groups. Made sure that non-admins can't control other groups.