### PR TITLE
Grades types should be unique

### DIFF
--- a/sql/courses.sql
+++ b/sql/courses.sql
@@ -32,7 +32,8 @@ CREATE TABLE instructors (
 CREATE TABLE grades_types (
     grades_type_id  INT          NOT NULL AUTO_INCREMENT,
     grades_type     VARCHAR(30)  NOT NULL, -- e.g. PASS-FAIL
-    PRIMARY KEY (grades_type_id)
+    PRIMARY KEY (grades_type_id),
+    UNIQUE (grades_type)
 );
 
 CREATE TABLE sections (


### PR DESCRIPTION
### Summary
Adds a `UNIQUE` constraint to `grades_types.grades_type`. This also gives us an index on the column which will be used for looking up the ID of existing grades types. (The table is very small though, so the performance benefits will be negligible.)

### Test Plan
Verified that the table doesn't currently contain duplicate entries:
```
MariaDB [donut]> SELECT * FROM grades_types;
+----------------+-------------+
| grades_type_id | grades_type |
+----------------+-------------+
|              1 | LETTER      |
|              2 |             |
|              3 | PASS-FAIL   |
+----------------+-------------+
3 rows in set (0.000 sec)
```

**Note to self: run `ALTER TABLE grades_types ADD UNIQUE (grades_type);` on prod DB when this is merged**
