### PR TITLE
Unpin py dependency of pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Flask==1.0.2
 flask_bootstrap==3.3.7.0
 itsdangerous==0.24
 MarkupSafe==0.23
-py==1.8.1
 pytest==5.3.5
 pytest-cov==2.8.1
 six==1.9.0


### PR DESCRIPTION
### Summary
Dependabot is warning about a security vulnerability in the `py` package (see #230). We don't use this package directly; it is indirectly required by `pytest`. We should allow `pytest` to select an appropriate version instead of pinning it to an old (potentially vulnerable) version.

### Test Plan
`make test` passes. Verified the reinstalling from `requirements.txt` upgrades `py` to the newest version:
```
$ pip show py
Name: py
Version: 1.10.0
Summary: library with cross-python path, ini-parsing, io, code, log facilities
Home-page: https://py.readthedocs.io/
Author: holger krekel, Ronny Pfannschmidt, Benjamin Peterson and others
Author-email: pytest-dev@python.org
License: MIT license
Location: /home/csander/virtualenvs/donut-py3.8/lib/python3.8/site-packages
Requires:
Required-by: pytest
```
