### PR TITLE
Don't show middle name if preferred name is set

### DIFF
--- a/donut/modules/directory_search/templates/view_user.html
+++ b/donut/modules/directory_search/templates/view_user.html
@@ -5,8 +5,10 @@
 			No such user!
 		{% else %}
 			<h2 class="pos-left">
-				{{ user['preferred_name'] or user['first_name'] }}
-				{{ user['middle_name'] or '' }}
+				{{
+					user['preferred_name'] or
+					user['first_name'] + ' ' + (user['middle_name'] or '')
+				}}
 				{{ user['last_name'] }}
 			</h2>
 			{% if user['image'] %}


### PR DESCRIPTION
### Summary
A preferred first name is often a user's middle name, so we shouldn't show both.

In the case where the preferred name only replaces the first name, it should be okay to not show the middle name. Users can always add their middle name to their preferred name if they want.

I considered showing the full name alongside the preferred name (e.g. `First Middle Last (Preferred)`), but this wouldn't allow users to hide their legal first name. 

### Test Plan
Viewed users with and without preferred names, both ones with and without middle names
