### PR TITLE
Set preferred name and gender to NULL if empty

### DIFF
--- a/donut/modules/core/routes.py
+++ b/donut/modules/core/routes.py
@@ -99,7 +99,7 @@ def set_image():
 def set_name():
     user_id = auth_utils.get_user_id(flask.session['username'])
     helpers.set_member_field(user_id, 'preferred_name',
-                             flask.request.form['name'])
+                             flask.request.form['name'] or None)
     return redirect(
         flask.url_for('directory_search.view_user', user_id=user_id))
 
@@ -108,7 +108,7 @@ def set_name():
 def set_gender():
     user_id = auth_utils.get_user_id(flask.session['username'])
     helpers.set_member_field(user_id, 'gender_custom',
-                             flask.request.form['gender'])
+                             flask.request.form['gender'] or None)
     return redirect(
         flask.url_for('directory_search.view_user', user_id=user_id))
 


### PR DESCRIPTION
### Summary
If the user submits an empty preferred name or gender, it should be set to `NULL` instead of the empty string. They are only used by the directory (verified by `grep`ing the code) and it only checks whether they are truthy, so `NULL` has the same effect as `''`. Always storing `NULL` makes it easier to determine which members have preferred names and genders and saves a bit on storage space.

### Test Plan
Tested setting and removing preferred names and genders, verifying that the directory display was correct and `NULL` was stored in the relevant columns

**Note to self: should run the following SQL to clean up the prod DB**
```sql
UPDATE members SET preferred_name = NULL WHERE preferred_name = '';
UPDATE members SET gender_custom = NULL WHERE gender_custom = '';
UPDATE members SET middle_name = NULL WHERE middle_name = '';
```
