### PR TITLE
Fix relative link for editor template uploaded_list.html

### DIFF
--- a/donut/modules/editor/templates/uploaded_list.html
+++ b/donut/modules/editor/templates/uploaded_list.html
@@ -1,1 +1,1 @@
-donut/modules/uploads/templates/uploaded_list.html
+../../uploads/templates/uploaded_list.html


### PR DESCRIPTION
### Summary
This file is symlinked to the template in the `uploads` module, but the link was incorrect. I'm not positive how this worked in the past; I think Flask looks for template files in other directories. I updated the link so it resolves to the correct file now.

### Test Plan
Verified that this page in the `editor` module and the `uploads` module renders correctly