### PR TITLE
Prevent exception for missing scheduler notes

### DIFF
--- a/donut/modules/courses/helpers.py
+++ b/donut/modules/courses/helpers.py
@@ -309,11 +309,12 @@ def get_notes(username, course, section):
     user_id = get_user_id(username)
     query = """
         SELECT notes FROM scheduler_sections
-        WHERE user_id= %s AND course_id = %s AND section_number = %s
+        WHERE user_id = %s AND course_id = %s AND section_number = %s
     """
     with flask.g.pymysql_db.cursor() as cursor:
         cursor.execute(query, (user_id, course, section))
-        return cursor.fetchone()['notes']
+        notes = cursor.fetchone()
+    return notes and notes['notes']
 
 
 def edit_notes(username, course, section, notes):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cov-core==1.15.0
 coverage==5.0.3
 Flask==1.0.2
 flask_bootstrap==3.3.7.0
+Werkzeug==1.*
 itsdangerous==0.24
 MarkupSafe==0.23
 pytest==5.3.5


### PR DESCRIPTION
Looks like we've been getting this exception somewhat frequently recently:
```
[2021-11-18 08:40:39,497] ERROR in app: Exception on /1/scheduler/notes/13775/section/5 [GET]
Traceback (most recent call last):
  File "/home/ascit/virtualenvs/donut-py3/lib/python3.8/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/ascit/virtualenvs/donut-py3/lib/python3.8/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/ascit/virtualenvs/donut-py3/lib/python3.8/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/ascit/virtualenvs/donut-py3/lib/python3.8/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/home/ascit/virtualenvs/donut-py3/lib/python3.8/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/ascit/virtualenvs/donut-py3/lib/python3.8/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/ascit/donut/donut/modules/courses/routes.py", line 208, in get_notes
    return flask.jsonify(helpers.get_notes(username, course, section))
  File "/home/ascit/donut/donut/modules/courses/helpers.py", line 316, in get_notes
    return cursor.fetchone()['notes']
TypeError: 'NoneType' object is not subscriptable
```

It seems like it's only possible for notes to be missing if the user deleted the section in a separate scheduler instance open concurrently. We don't really support having multiple schedulers open for the same user, but should handle the case gracefully by pretending the section has no notes. The client-side code can already handle the notes being null.

Also pins Werkzeug to an older version since version 2.x breaks the tests.

### Test Plan

Verified that the notes functionality still works normally for sections that haven't been deleted. Tried deleting a section with notes in a separate tab and checked that the notes show up as empty when clicking on the section in the original tab.