### PR TITLE
Limit uploads to 10 MB (instead of 1 GB)

### DIFF
--- a/donut/__init__.py
+++ b/donut/__init__.py
@@ -151,6 +151,14 @@ def access_forbidden(error):
     return flask.render_template("403.html"), http.client.FORBIDDEN
 
 
+@app.errorhandler(http.client.REQUEST_ENTITY_TOO_LARGE)
+def upload_too_large(error):
+    """ Handles a 413 Payload Too Large error. """
+    max_size = constants.MAX_CONTENT_LENGTH_STRING
+    return flask.render_template("413.html", max_size=max_size), \
+        http.client.REQUEST_ENTITY_TOO_LARGE
+
+
 @app.errorhandler(http.client.INTERNAL_SERVER_ERROR)
 def internal_server_error(error):
     """

--- a/donut/constants.py
+++ b/donut/constants.py
@@ -2,7 +2,8 @@
 from enum import Enum
 
 # Maximum file upload size (in bytes).
-MAX_CONTENT_LENGTH = 1 * 1024 * 1024 * 1024
+MAX_CONTENT_LENGTH = 10 * 1024 * 1024
+MAX_CONTENT_LENGTH_STRING = '10 MB'
 
 # Authentication/account creation constants
 PWD_HASH_ALGORITHM = 'pbkdf2_sha256'

--- a/donut/templates/413.html
+++ b/donut/templates/413.html
@@ -1,0 +1,10 @@
+{% extends "layout.html" %}
+{% block page %}
+<div class="container theme-showcase" role="main">
+	<div class="jumbotron">
+		<h2>Uploaded file is too large</h2>
+		<br>
+		<p>Please limit uploads to {{ max_size }}.</p>
+	</div>
+</div>
+{% endblock page %}


### PR DESCRIPTION
Currently, the database crashes when we try to feed it a directory image much larger than 10 MB. This leads to an "500 Internal Server Error" message, which is very unhelpful. It also makes the website unusable for other users until the database can be restarted, which is really bad.

So use a lower upload size limit and show a more helpful 413 error page if the upload is too large.

### Test Plan

Tried uploading a 15 MB directory image and verified that it immediately returned a 413 error page saying the limit was 10 MB. Smaller images work normally. Verified unit change algorithm also works if the size limit exceeds the largest unit (e.g. will show 10240 KB instead).
